### PR TITLE
Refactor advice primitives, unify icon mapping, and centralize background token

### DIFF
--- a/CLEANUP_PLAN.md
+++ b/CLEANUP_PLAN.md
@@ -1,0 +1,212 @@
+## Codebase Cleanup and Improvement Plan
+
+This document captures duplication, unused code/assets, and development artifacts found in the repository, plus a prioritized, actionable plan to address them.
+
+### Scope
+- App: `src/app/*`
+- Components: `src/components/*`
+- Hooks: `src/hooks/*`
+- Lib/Config: `src/lib/*`
+- Public assets: `public/*`
+- Tests and tooling: `__tests__/*`, `jest.*`, `playwright.*`
+
+---
+
+## Findings
+
+### 1) Code Duplication
+
+- **Advice card family (UI duplication)**: `MetaItem`, `MetaItemAd`, `Interesting`, `Cover`, `RD` share card container patterns (rounded, shadow, image + title/subtitle, click handler). Extract shared primitives:
+  - `AdviceCardContainer` (padding, radius, hover, layout)
+  - `AdviceCardTitle`, `AdviceCardSubtitle`, `AdviceCardBadge`
+  - Centralize shared spacing and typography.
+
+- **Inline color tokens duplicated**:
+  - Repeated `bg-[#F1F1F1]` in `Dashboard`, `test-*` pages. Use `COLORS` or Tailwind theme token.
+
+- **Icon mapping duplication/misalignment**:
+  - `src/components/icons/Icon.tsx` contains inline SVGs for `search`, `menu`, `home`, `work`, `bookmark`, `location`.
+  - `src/lib/icons/index.ts` defines `ICONS` and `ICON_SVGS` paths but `Icon` does not consume `ICON_SVGS`.
+  - Some `ICONS` entries exist without SVGs in `Icon` (`traffic-*`).
+
+- **Test instrumentation repeats env checks**:
+  - `process.env.NEXT_PUBLIC_ENABLE_TEST_HOOKS === 'true'` blocks repeated in `MapContainer`, `MapProvider`. Consider a small helper `isTestHooksEnabled()`.
+
+### 2) CSS/Styling Duplication
+
+- **Repeated colors**:
+  - `#F1F1F1` hardcoded in multiple places (`Dashboard`, `test-advice`, `test-stories`). Add Tailwind theme color or reuse `COLORS`.
+  - Text grays (e.g., `text-gray-600`) appear repeatedly; consider aliasing via Tailwind theme extensions where design requires stability.
+
+- **Global CSS minimal**: Only theme vars and dark-scheme media query exist in `globals.css`. Most styling is Tailwind-based. Prefer tokens over one-off hex values.
+
+### 3) Logic Duplication
+
+- **Click logging across many components**:
+  - `Dashboard`, `Advice*` components, and dev pages all log with `console.log` for click handlers. Gate behind a feature flag or remove in production builds.
+
+- **Map init/destroy patterns**:
+  - Safe-destroy logic repeated with try/catch in `MapContainer`. If needed in other modules later, extract to a small utility.
+
+### 4) Unused Code and Components
+
+- **Likely unused runtime components**:
+  - `LocationList` and `PlaceDetails` are referenced in docs/tests but not rendered in the main app. Evaluate removal or move to examples.
+
+- **Dev-only pages** (ship-blockers unless guarded):
+  - `src/app/test-advice/page.tsx`
+  - `src/app/test-icons/page.tsx`
+  - `src/app/test-stories/page.tsx`
+  - Keep only when `NEXT_PUBLIC_ENABLE_DEV_PAGES === 'true'` or remove.
+
+- **Unused icon mappings**:
+  - `ICON_SVGS` exported but not used by `Icon`.
+  - `ICONS.TRAFFIC_*` exist without corresponding inline SVG support; used only in dev page for color showcase.
+
+### 5) Unused Assets (likely)
+
+- `public/assets` contains 150+ files. Only a subset is referenced under `src/*` (e.g., advice/stories). Many advice icons appear unused.
+- Action: generate unused-assets report (see plan) and prune with review.
+
+### 6) Dead Code Paths
+
+- No unreachable branches detected in code scan, but many handlers are dev logs only.
+- `__tests__/integration/interactions/map-sheet-sync.test.tsx.skip` is skipped (test never runs). Decide to fix or delete.
+
+### 7) Development Artifacts
+
+- **Console statements** in production code:
+  - Examples: `src/components/map/MapContainer.tsx`, `src/components/dashboard/*`, `src/components/dashboard/advice/*`.
+  - Replace with `debug()` helper gated by env, or remove.
+
+- **Mock/test data in production bundle path**:
+  - `src/components/dashboard/advice/mockData.ts` used by `Dashboard`. Consider moving to `src/__mocks__/` or a dev-only provider.
+
+- **Dev-only pages** under `src/app/test-*` (see above).
+
+- **Skipped test**: `map-sheet-sync.test.tsx.skip`.
+
+---
+
+## Prioritized Action Plan
+
+### Phase 0 — Safety net
+- **Add CI checks**: run unit + integration + e2e; TypeScript; ESLint.
+- **Add bundle guard**: ensure dev pages and console logs are stripped in `production`.
+
+### Phase 1 — High-impact, low-risk
+
+1. Remove or guard dev-only pages
+   - Path: `src/app/test-advice/page.tsx`, `src/app/test-icons/page.tsx`, `src/app/test-stories/page.tsx`.
+   - Option A: delete; Option B: export only when `NEXT_PUBLIC_ENABLE_DEV_PAGES === 'true'`.
+   - Acceptance: no routes exposed in production.
+
+2. Replace console.* in runtime code
+   - Create `src/lib/log.ts` with `debug/info/warn/error` gated by `NEXT_PUBLIC_DEBUG === 'true'`.
+   - Refactor occurrences in `MapContainer`, `MapProvider`, `Dashboard`, advice components.
+   - Acceptance: zero raw `console.log` in `src/components/**`.
+
+3. Move mock data to dev scope
+   - `src/components/dashboard/advice/mockData.ts` → `src/__mocks__/advice/mockData.ts`.
+   - For `Dashboard`, introduce a prop `items?: AdviceItem[]` and pass `mockAdviceItems` only in dev/demo pages.
+   - Acceptance: production `Dashboard` does not import mocks.
+
+4. Align Icon system
+   - Option A: Make `Icon` consume `ICON_SVGS` via `<img>`/`<svg>` fetch or inline via SVGR.
+   - Option B: Remove `ICON_SVGS` and keep inline canonical SVGs in `Icon` + complete missing icons or remove dead names from `ICONS` (traffic-*).
+   - Acceptance: `ICONS` names match actual renderable icons; no dead names.
+
+5. Centralize colors
+   - Add Tailwind theme tokens (extend colors) for background and text neutrals.
+   - Replace hard-coded `#F1F1F1` and repeated grays with tokens or `COLORS`.
+   - Acceptance: no raw `#F1F1F1` in components.
+
+6. Unused assets report and pruning
+   - Script: scan `public/assets/**/*` and grep references in `src/**`. Produce `scripts/unused-assets.json`.
+   - Manually review and delete assets not used.
+   - Acceptance: `public/assets` reduced to referenced files only.
+
+### Phase 2 — Structural cleanup
+
+7. Extract Advice UI primitives
+   - Create `src/components/dashboard/advice/primitives/*` with shared container, title, badge, image wrappers.
+   - Refactor `MetaItem`, `MetaItemAd`, `Interesting`, `Cover`, `RD` to use primitives.
+   - Acceptance: reduced duplicate JSX and classNames across advice family; smaller diffs for future changes.
+
+8. DRY test-hooks checks
+   - Add `src/lib/testHooks.ts`:
+     - `export const isTestHooksEnabled = () => process.env.NEXT_PUBLIC_ENABLE_TEST_HOOKS === 'true'`.
+     - Replace repeated literals in `MapContainer`, `MapProvider`.
+   - Acceptance: single source of truth for test hook gating.
+
+9. Evaluate `LocationList` and `PlaceDetails`
+   - If only for documentation/examples, move to `docs/examples` or delete.
+   - Acceptance: no unused exports in production bundle path.
+
+10. Re-enable or remove skipped test
+   - `__tests__/integration/interactions/map-sheet-sync.test.tsx.skip` → fix and enable, or delete.
+   - Acceptance: no skipped tests in CI.
+
+### Phase 3 — Optional enhancements
+
+11. Map instance wiring
+   - Replace `window.__setMapInstance` handshake with context or event emitter under the provider, if feasible.
+   - Acceptance: no global window mutation for core flow.
+
+12. Tailwind design tokens
+   - Mirror `COLORS` into Tailwind config for class-based usage instead of inline styles.
+   - Acceptance: consistent token usage across utility classes and inline styles.
+
+---
+
+## Concrete Tasks Checklist
+
+- [ ] Guard or remove dev pages: `src/app/test-*`
+- [ ] Create `src/lib/log.ts` and replace raw console statements
+- [ ] Move `mockData.ts` to `src/__mocks__/advice/` and decouple `Dashboard` from mocks
+- [ ] Decide on icon strategy; align `ICONS` names and actual renders
+- [ ] Add Tailwind color tokens and replace hard-coded hexes
+- [ ] Implement asset usage scanner; prune unreferenced files
+- [ ] Extract `advice/primitives/*`; refactor card components
+- [ ] Add `isTestHooksEnabled()` helper; use in map components
+- [ ] Decide fate of `LocationList` and `PlaceDetails`
+- [ ] Unskip or remove `map-sheet-sync.test.tsx.skip`
+
+---
+
+## References (examples)
+
+```25:94:src/components/map/MapContainer.tsx
+            console.warn('Failed to destroy existing map instance:', error);
+...
+             console.log('Map clicked at:', mapEvent.lngLat);
+```
+
+```21:44:src/components/dashboard/Dashboard.tsx
+  const handleSearch = (query: string) => {
+    console.log('Search query:', query);
+    onSearch?.(query);
+  };
+```
+
+```14:45:src/components/dashboard/advice/mockData.ts
+export const mockAdviceItems: AdviceItem[] = [
+  // Figma-derived data
+```
+
+```38:76:src/lib/icons/index.ts
+export const ICON_SVGS = {
+  SEARCH: '/assets/icons/78b4...svg',
+  MENU: '/assets/icons/249a...svg',
+}
+```
+
+---
+
+## Rollout Notes
+
+- Tackle Phase 1 in a single PR to reduce churn and risk.
+- Schedule Phase 2 refactors after a tag/release; ensure visual regressions are covered by screenshot tests.
+- Document deprecated exports in `CHANGELOG.md` if any public APIs change.
+
+

--- a/src/app/test-advice/page.tsx
+++ b/src/app/test-advice/page.tsx
@@ -84,7 +84,7 @@ export default function TestAdvicePage() {
           {/* Light theme */}
           <div>
             <h3 className="text-sm font-medium text-gray-600 mb-2">Light Theme</h3>
-            <div className="bg-[#F1F1F1] p-4 rounded-lg">
+            <div className="p-4 rounded-lg" style={{ backgroundColor: 'var(--bg-muted, #F1F1F1)' }}>
               <div className="grid grid-cols-2 gap-3 max-w-md">
                 <MetaItem
                   id="meta-light-1"
@@ -149,7 +149,7 @@ export default function TestAdvicePage() {
           {/* Light theme */}
           <div>
             <h3 className="text-sm font-medium text-gray-600 mb-2">Light Theme</h3>
-            <div className="bg-[#F1F1F1] p-4 rounded-lg">
+            <div className="p-4 rounded-lg" style={{ backgroundColor: 'var(--bg-muted, #F1F1F1)' }}>
               <div className="grid grid-cols-2 gap-3 max-w-md">
                 <MetaItemAd
                   id="ad-light-1"
@@ -217,7 +217,7 @@ export default function TestAdvicePage() {
           {/* Light theme */}
           <div>
             <h3 className="text-sm font-medium text-gray-600 mb-2">Light Theme</h3>
-            <div className="bg-[#F1F1F1] p-4 rounded-lg">
+            <div className="p-4 rounded-lg" style={{ backgroundColor: 'var(--bg-muted, #F1F1F1)' }}>
               <div className="grid grid-cols-2 gap-3 max-w-md">
                 <Interesting
                   id="light-1"
@@ -280,7 +280,7 @@ export default function TestAdvicePage() {
           {/* Light theme */}
           <div>
             <h3 className="text-sm font-medium text-gray-600 mb-2">Light Theme</h3>
-            <div className="bg-[#F1F1F1] p-4 rounded-lg">
+            <div className="p-4 rounded-lg" style={{ backgroundColor: 'var(--bg-muted, #F1F1F1)' }}>
               <div className="grid grid-cols-2 gap-3 max-w-md">
                 <RD
                   id="rd-light-1"
@@ -356,7 +356,7 @@ export default function TestAdvicePage() {
           {/* With many images showing counter */}
           <div>
             <h3 className="text-sm font-medium text-gray-600 mb-2">With Image Counter</h3>
-            <div className="bg-[#F1F1F1] p-4 rounded-lg">
+            <div className="p-4 rounded-lg" style={{ backgroundColor: 'var(--bg-muted, #F1F1F1)' }}>
               <div className="max-w-[220px]">
                 <RD
                   id="rd-counter"
@@ -385,7 +385,7 @@ export default function TestAdvicePage() {
           {/* Default state */}
           <div>
             <h3 className="text-sm font-medium text-gray-600 mb-2">Default State (142px height)</h3>
-            <div className="bg-[#F1F1F1] p-4 rounded-lg">
+            <div className="p-4 rounded-lg" style={{ backgroundColor: 'var(--bg-muted, #F1F1F1)' }}>
               <div className="max-w-md">
                 <Cover
                   id="cover-default-1"
@@ -405,7 +405,7 @@ export default function TestAdvicePage() {
           {/* Big state */}
           <div>
             <h3 className="text-sm font-medium text-gray-600 mb-2">Big State (200px height)</h3>
-            <div className="bg-[#F1F1F1] p-4 rounded-lg">
+            <div className="p-4 rounded-lg" style={{ backgroundColor: 'var(--bg-muted, #F1F1F1)' }}>
               <div className="max-w-md">
                 <Cover
                   id="cover-big-1"
@@ -425,7 +425,7 @@ export default function TestAdvicePage() {
           {/* Minimal content */}
           <div>
             <h3 className="text-sm font-medium text-gray-600 mb-2">Minimal Content</h3>
-            <div className="bg-[#F1F1F1] p-4 rounded-lg">
+            <div className="p-4 rounded-lg" style={{ backgroundColor: 'var(--bg-muted, #F1F1F1)' }}>
               <div className="max-w-md">
                 <Cover
                   id="cover-minimal"
@@ -479,7 +479,7 @@ export default function TestAdvicePage() {
       {/* Full Advice Section */}
       <section>
         <h2 className="text-lg font-semibold mb-4">Full Advice Section</h2>
-        <div className="bg-[#F1F1F1] p-4 rounded-lg">
+        <div className="p-4 rounded-lg" style={{ backgroundColor: 'var(--bg-muted, #F1F1F1)' }}>
           <AdviceSection
             items={[
               interestingLight,

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -59,8 +59,8 @@ export function Dashboard({
         </div>
       </div>
 
-      {/* Stories Panel and subsequent blocks on #F1F1F1 background */}
-      <div className="flex-1 bg-[#F1F1F1] overflow-y-auto">
+      {/* Stories Panel and subsequent blocks on muted background */}
+      <div className="flex-1 overflow-y-auto" style={{ backgroundColor: 'var(--bg-muted, #F1F1F1)' }}>
         {/* Stories Panel */}
         <div className="pt-4 pb-4">
           <StoriesPanel onStoryClick={handleStoryClick} />

--- a/src/components/dashboard/advice/AdviceSection.tsx
+++ b/src/components/dashboard/advice/AdviceSection.tsx
@@ -155,7 +155,7 @@ export function AdviceSection({
   };
 
   return (
-    <div className={`w-full bg-[#F1F1F1] ${className}`}>
+    <div className={`w-full ${className}`} style={{ backgroundColor: 'var(--bg-muted, #F1F1F1)' }}>
       {/* Section title - exact Figma specs */}
       <div className="px-4 pb-3">
         <h2 className="font-semibold text-[19px] leading-6 tracking-[-0.38px] text-[#141414]">

--- a/src/components/dashboard/advice/Cover.tsx
+++ b/src/components/dashboard/advice/Cover.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { CoverProps } from './types';
+import { AdviceCardContainer } from './primitives';
 
 /**
  * Cover Component
@@ -48,59 +49,36 @@ export function Cover({
   };
 
   return (
-    <button
+    <AdviceCardContainer
       onClick={handleClick}
-      className={`
-        relative w-full ${height}
-        rounded-xl overflow-hidden
-        transition-transform active:scale-95
-        bg-white
-        ${className}
-      `}
+      className={`${className}`}
+      heightClassName={height}
       aria-label={`Collection: ${title}`}
       data-collection-id={collectionId}
       data-item-id={id}
     >
-      {/* Background image */}
-      <div 
-        className="absolute inset-0 bg-cover bg-center bg-no-repeat"
-        style={{ backgroundImage: `url('${imageUrl}')` }}
-      />
+      <div className="absolute inset-0 bg-cover bg-center bg-no-repeat" style={{ backgroundImage: `url('${imageUrl}')` }} />
 
-      {/* Overlay - different for Default vs Big state */}
       {isBig ? (
-        // Big state: simple dark overlay
         <div className="absolute inset-0 rounded-xl bg-black/40" />
       ) : (
-        // Default state: gradient overlay
-        <div 
+        <div
           className="absolute inset-0 rounded-xl"
           style={{
-            background: 'linear-gradient(180deg, rgba(0, 0, 0, 0.6) 0%, rgba(0, 0, 0, 0.28) 42.336%, rgba(0, 0, 0, 0) 100%)',
+            background:
+              'linear-gradient(180deg, rgba(0, 0, 0, 0.6) 0%, rgba(0, 0, 0, 0.28) 42.336%, rgba(0, 0, 0, 0) 100%)',
           }}
         />
       )}
 
-      {/* Text content */}
       <div className="absolute inset-0 px-4 pt-2.5 pb-0 flex flex-col">
-        {/* Title */}
-        <h3 className="font-medium text-[16px] leading-5 tracking-[-0.24px] text-white text-left">
-          {title}
-        </h3>
-        
-        {/* Subtitle/metadata */}
+        <h3 className="font-medium text-[16px] leading-5 tracking-[-0.24px] text-white text-left">{title}</h3>
         {getSubtitleText() && (
-          <p className="text-[13px] leading-4 tracking-[-0.234px] text-white text-left mt-0.5">
-            {getSubtitleText()}
-          </p>
+          <p className="text-[13px] leading-4 tracking-[-0.234px] text-white text-left mt-0.5">{getSubtitleText()}</p>
         )}
       </div>
 
-      {/* Border */}
-      <div 
-        className="absolute inset-0 border-[0.5px] border-[rgba(137,137,137,0.3)] rounded-xl pointer-events-none"
-        aria-hidden="true"
-      />
-    </button>
+      <div className="absolute inset-0 border-[0.5px] border-[rgba(137,137,137,0.3)] rounded-xl pointer-events-none" aria-hidden="true" />
+    </AdviceCardContainer>
   );
 }

--- a/src/components/dashboard/advice/Interesting.tsx
+++ b/src/components/dashboard/advice/Interesting.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { InterestingProps } from './types';
+import { AdviceCardContainer, AdviceTitle, AdviceBodyText, AdviceBadge } from './primitives';
 
 /**
  * Interesting Component
@@ -35,65 +36,37 @@ export function Interesting({
   };
 
   const isLight = theme === 'Light';
-  // Interesting is always double height (244px) in masonry layout
   const minHeight = 'min-h-[244px]';
-  
+
   return (
-    <button
+    <AdviceCardContainer
       onClick={handleClick}
-      className={`
-        relative w-full h-full ${minHeight}
-        rounded-xl overflow-hidden
-        flex flex-col
-        transition-transform active:scale-95
-        ${isLight ? 'bg-white' : 'bg-white/[0.06]'}
-        ${className}
-      `}
+      className={`flex flex-col ${className}`}
+      heightClassName={`h-full ${minHeight}`}
+      theme={theme}
       aria-label={`Feature: ${title}`}
       data-feature-id={featureId}
       data-item-id={id}
     >
-      {/* Badge if present */}
       {badge && (
         <div className="absolute top-2 right-2 z-10">
-          <span className="text-[10px] font-semibold text-white bg-red-500 px-2 py-1 rounded-full">
-            {badge}
-          </span>
+          <AdviceBadge text={badge} />
         </div>
       )}
 
-      {/* Text content */}
       <div className="flex flex-col items-start px-4 pt-2.5 pb-3">
-        <h3 
-          className={`
-            font-medium text-[16px] leading-5 tracking-[-0.24px] text-left
-            ${isLight ? 'text-[#141414]' : 'text-white'}
-          `}
-        >
+        <AdviceTitle theme={theme} className="text-left">
           {title}
-        </h3>
-        <p 
-          className="text-[14px] leading-[18px] tracking-[-0.28px] text-[#898989] text-left mt-0.5"
-        >
-          {description}
-        </p>
+        </AdviceTitle>
+        <AdviceBodyText className="text-left mt-0.5">{description}</AdviceBodyText>
         {actionText && (
-          <span 
-            className={`
-              text-[14px] font-medium mt-2
-              ${isLight ? 'text-blue-600' : 'text-blue-400'}
-            `}
-          >
+          <span className={`text-[14px] font-medium mt-2 ${isLight ? 'text-blue-600' : 'text-blue-400'}`}>
             {actionText} →
           </span>
         )}
       </div>
 
-      {/* Image at bottom - takes remaining space */}
-      <div 
-        className="flex-1 w-full bg-center bg-contain bg-no-repeat"
-        style={{ backgroundImage: `url('${imageUrl}')` }}
-      />
-    </button>
+      <div className="flex-1 w-full bg-center bg-contain bg-no-repeat" style={{ backgroundImage: `url('${imageUrl}')` }} />
+    </AdviceCardContainer>
   );
 }

--- a/src/components/dashboard/advice/MetaItem.tsx
+++ b/src/components/dashboard/advice/MetaItem.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { MetaItemProps } from './types';
+import { AdviceCardContainer, AdviceIconCircle, AdviceTitle, AdviceSubtitle } from './primitives';
 
 /**
  * MetaItem Component
@@ -35,57 +36,31 @@ export function MetaItem({
   const isLight = theme === 'Light';
 
   return (
-    <button
+    <AdviceCardContainer
       onClick={handleClick}
-      className={`
-        relative w-full h-[116px]
-        rounded-xl
-        flex flex-col justify-between
-        px-4 pb-3 pt-2.5
-        transition-transform active:scale-95
-        ${isLight ? 'bg-white' : 'bg-white/[0.06]'}
-        ${className}
-      `}
+      className={`flex flex-col justify-between px-4 pb-3 pt-2.5 ${className}`}
+      heightClassName="h-[116px]"
+      theme={theme}
       aria-label={`Search in ${title}`}
       data-category-id={categoryId}
       data-item-id={id}
     >
-      {/* Text content */}
       <div className="flex flex-col items-start">
-        <h3 
-          className={`
-            font-medium text-[16px] leading-5 tracking-[-0.24px] text-left
-            line-clamp-2
-            ${isLight ? 'text-[#141414]' : 'text-white'}
-          `}
-        >
+        <AdviceTitle theme={theme} className="text-left line-clamp-2">
           {title}
-        </h3>
+        </AdviceTitle>
         {subtitle && (
-          <p className="text-[13px] leading-4 tracking-[-0.234px] text-[#898989] text-left mt-0.5">
-            {subtitle}
-          </p>
+          <AdviceSubtitle className="text-left mt-0.5">{subtitle}</AdviceSubtitle>
         )}
       </div>
-      
-      {/* Icon in bottom-right */}
+
       {iconUrl && (
         <div className="flex justify-end">
-          <div 
-            className={`
-              w-12 h-12 rounded-full
-              flex items-center justify-center
-              ${isLight ? 'bg-[rgba(20,20,20,0.06)]' : 'bg-white/[0.06]'}
-            `}
-          >
-            <img 
-              src={iconUrl} 
-              alt="" 
-              className="w-8 h-8"
-            />
-          </div>
+          <AdviceIconCircle isLight={isLight}>
+            <img src={iconUrl} alt="" className="w-8 h-8" />
+          </AdviceIconCircle>
         </div>
       )}
-    </button>
+    </AdviceCardContainer>
   );
 }

--- a/src/components/dashboard/advice/MetaItemAd.tsx
+++ b/src/components/dashboard/advice/MetaItemAd.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { MetaItemAdProps } from './types';
+import { AdviceCardContainer, AdviceTitle, AdviceLogoCircle } from './primitives';
 
 /**
  * MetaItemAd Component
@@ -38,20 +39,15 @@ export function MetaItemAd({
   const isLight = theme === 'Light';
 
   return (
-    <button
+    <AdviceCardContainer
       onClick={handleClick}
-      className={`
-        relative w-full h-[116px]
-        rounded-xl overflow-hidden
-        transition-transform active:scale-95
-        ${isLight ? 'bg-white' : 'bg-white/[0.06]'}
-        ${className}
-      `}
+      className={className}
+      heightClassName="h-[116px]"
+      theme={theme}
       aria-label={`Sponsored: ${title}`}
       data-advertiser-id={advertiserId}
       data-item-id={id}
     >
-      {/* Gradient background overlay with mask */}
       {gradientMaskUrl && (
         <div
           className="absolute inset-0"
@@ -69,51 +65,35 @@ export function MetaItemAd({
         />
       )}
 
-      {/* Logo in bottom-right */}
       {logoUrl && (
         <div className="absolute bottom-3 right-4">
-          <div className="w-12 h-12 bg-white rounded-full overflow-hidden border-[0.5px] border-[rgba(137,137,137,0.3)]">
-            <img 
-              src={logoUrl} 
-              alt="" 
-              className="w-full h-full object-cover"
-            />
-          </div>
+          <AdviceLogoCircle>
+            <img src={logoUrl} alt="" className="w-full h-full object-cover" />
+          </AdviceLogoCircle>
         </div>
       )}
 
-      {/* Text content */}
       <div className="absolute inset-0 px-4 pt-2.5 pb-[13px] flex flex-col justify-between">
-        <h3 
-          className={`
-            font-medium text-[16px] leading-5 tracking-[-0.24px] text-left
-            ${isLight ? 'text-[#141414]' : 'text-white'}
-          `}
-        >
+        <AdviceTitle theme={theme} className="text-left">
           {title}
-        </h3>
-        
-        {/* Advertisement label */}
+        </AdviceTitle>
         {isSponsored && (
-          <p 
-            className={`
-              text-[11px] leading-[14px] tracking-[-0.176px] text-left
-              ${isLight ? 'text-[rgba(20,20,20,0.3)]' : 'text-white/30'}
-            `}
+          <p
+            className={`text-[11px] leading-[14px] tracking-[-0.176px] text-left ${
+              isLight ? 'text-[rgba(20,20,20,0.3)]' : 'text-white/30'
+            }`}
           >
             Реклама
           </p>
         )}
       </div>
 
-      {/* Border */}
-      <div 
-        className={`
-          absolute inset-0 border rounded-xl pointer-events-none
-          ${isLight ? 'border-[rgba(20,20,20,0.06)]' : 'border-white/[0.06]'}
-        `}
+      <div
+        className={`absolute inset-0 border rounded-xl pointer-events-none ${
+          isLight ? 'border-[rgba(20,20,20,0.06)]' : 'border-white/[0.06]'
+        }`}
         aria-hidden="true"
       />
-    </button>
+    </AdviceCardContainer>
   );
 }

--- a/src/components/dashboard/advice/RD.tsx
+++ b/src/components/dashboard/advice/RD.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { RDProps } from './types';
+import { AdviceCardContainer, AdviceBodyText, AdviceTitle } from './primitives';
 
 /**
  * RD (РекламоДатель/Advertiser) Component
@@ -63,15 +64,11 @@ export function RD({
   ) : null;
 
   return (
-    <button
+    <AdviceCardContainer
       onClick={handleClick}
-      className={`
-        relative w-full h-[244px]
-        rounded-xl overflow-hidden
-        transition-transform active:scale-95
-        ${isLight ? 'bg-white' : 'bg-white/[0.06]'}
-        ${className}
-      `}
+      className={`${className}`}
+      heightClassName="h-[244px]"
+      theme={theme}
       aria-label={`Advertiser: ${advertiserName}`}
       data-organization-id={organizationId}
       data-item-id={id}
@@ -124,20 +121,15 @@ export function RD({
         <div className="flex-1 flex flex-col">
           {/* Title with verified badge */}
           <div className="flex items-center">
-            <h3 className={`
-              font-semibold text-[16px] leading-5 tracking-[-0.24px]
-              ${isLight ? 'text-[#141414]' : 'text-white'}
-            `}>
+            <AdviceTitle theme={theme} className="font-semibold">
               {advertiserName}
-            </h3>
+            </AdviceTitle>
             {crownIcon}
           </div>
           
           {/* Subtitle */}
           {subtitle && (
-            <p className="text-[14px] leading-[18px] tracking-[-0.28px] text-[#898989] mt-0.5">
-              {subtitle}
-            </p>
+            <AdviceBodyText className="mt-0.5">{subtitle}</AdviceBodyText>
           )}
 
           {/* Rating and distance row */}
@@ -155,9 +147,7 @@ export function RD({
                 </div>
               )}
               {distance && (
-                <span className="font-medium text-[14px] leading-[18px] tracking-[-0.28px] text-[#898989]">
-                  {distance}
-                </span>
+                <span className="font-medium text-[14px] leading-[18px] tracking-[-0.28px] text-[#898989]">{distance}</span>
               )}
             </div>
           )}
@@ -165,9 +155,7 @@ export function RD({
 
         {/* Address at bottom */}
         {address && (
-          <p className="text-[14px] leading-[18px] tracking-[-0.28px] text-[#898989]">
-            {address}
-          </p>
+          <AdviceBodyText>{address}</AdviceBodyText>
         )}
       </div>
 
@@ -179,6 +167,6 @@ export function RD({
         `}
         aria-hidden="true"
       />
-    </button>
+    </AdviceCardContainer>
   );
 }

--- a/src/components/dashboard/advice/primitives/AdviceBadge.tsx
+++ b/src/components/dashboard/advice/primitives/AdviceBadge.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import React from 'react';
+
+interface AdviceBadgeProps {
+  text: string;
+  className?: string;
+}
+
+export function AdviceBadge({ text, className = '' }: AdviceBadgeProps) {
+  return (
+    <span className={`text-[10px] font-semibold text-white bg-red-500 px-2 py-1 rounded-full ${className}`}>
+      {text}
+    </span>
+  );
+}
+
+

--- a/src/components/dashboard/advice/primitives/AdviceCardContainer.tsx
+++ b/src/components/dashboard/advice/primitives/AdviceCardContainer.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import React from 'react';
+
+export type AdviceTheme = 'Light' | 'Dark';
+
+interface AdviceCardContainerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  theme?: AdviceTheme;
+  heightClassName?: string; // e.g. h-[116px], min-h-[244px]
+}
+
+export function AdviceCardContainer({
+  theme = 'Light',
+  className = '',
+  heightClassName = '',
+  children,
+  ...buttonProps
+}: AdviceCardContainerProps) {
+  const isLight = theme === 'Light';
+  return (
+    <button
+      {...buttonProps}
+      className={`
+        relative w-full ${heightClassName}
+        rounded-xl overflow-hidden
+        transition-transform active:scale-95
+        ${isLight ? 'bg-white' : 'bg-white/[0.06]'}
+        ${className}
+      `}
+    >
+      {children}
+    </button>
+  );
+}
+
+

--- a/src/components/dashboard/advice/primitives/AdviceCardText.tsx
+++ b/src/components/dashboard/advice/primitives/AdviceCardText.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React from 'react';
+import type { AdviceTheme } from './AdviceCardContainer';
+
+interface TitleProps {
+  theme?: AdviceTheme;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function AdviceTitle({ theme = 'Light', className = '', children }: TitleProps) {
+  const isLight = theme === 'Light';
+  return (
+    <h3
+      className={`
+        font-medium text-[16px] leading-5 tracking-[-0.24px]
+        ${isLight ? 'text-[#141414]' : 'text-white'}
+        ${className}
+      `}
+    >
+      {children}
+    </h3>
+  );
+}
+
+interface SubtitleProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function AdviceSubtitle({ className = '', children }: SubtitleProps) {
+  return (
+    <p className={`text-[13px] leading-4 tracking-[-0.234px] text-[#898989] ${className}`}>
+      {children}
+    </p>
+  );
+}
+
+interface BodyTextProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function AdviceBodyText({ className = '', children }: BodyTextProps) {
+  return (
+    <p className={`text-[14px] leading-[18px] tracking-[-0.28px] text-[#898989] ${className}`}>
+      {children}
+    </p>
+  );
+}
+
+

--- a/src/components/dashboard/advice/primitives/AdviceMedia.tsx
+++ b/src/components/dashboard/advice/primitives/AdviceMedia.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React from 'react';
+
+interface AdviceIconCircleProps {
+  isLight?: boolean;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function AdviceIconCircle({ isLight = true, className = '', children }: AdviceIconCircleProps) {
+  return (
+    <div
+      className={`
+        w-12 h-12 rounded-full flex items-center justify-center
+        ${isLight ? 'bg-[rgba(20,20,20,0.06)]' : 'bg-white/[0.06]'}
+        ${className}
+      `}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface AdviceLogoCircleProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function AdviceLogoCircle({ className = '', children }: AdviceLogoCircleProps) {
+  return (
+    <div className={`w-12 h-12 bg-white rounded-full overflow-hidden border-[0.5px] border-[rgba(137,137,137,0.3)] ${className}`}>
+      {children}
+    </div>
+  );
+}
+
+interface BackgroundImageProps {
+  imageUrl: string;
+  className?: string;
+}
+
+export function BackgroundImage({ imageUrl, className = '' }: BackgroundImageProps) {
+  return (
+    <div className={`absolute inset-0 bg-cover bg-center bg-no-repeat ${className}`} style={{ backgroundImage: `url('${imageUrl}')` }} />
+  );
+}
+
+

--- a/src/components/dashboard/advice/primitives/index.ts
+++ b/src/components/dashboard/advice/primitives/index.ts
@@ -1,0 +1,6 @@
+export { AdviceCardContainer } from './AdviceCardContainer';
+export { AdviceTitle, AdviceSubtitle, AdviceBodyText } from './AdviceCardText';
+export { AdviceBadge } from './AdviceBadge';
+export { AdviceIconCircle, AdviceLogoCircle, BackgroundImage } from './AdviceMedia';
+
+

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -1,6 +1,8 @@
+
 'use client';
 
 import React from 'react';
+import { ICON_SVGS } from '@/lib/icons';
 
 interface IconProps {
   name: string;
@@ -154,12 +156,35 @@ export function Icon({
         />
       </svg>
     ),
+    // Traffic icons (simple circle indicators)
+    'traffic-heavy': (
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} style={{ display: 'block' }}>
+        <circle cx="6" cy="6" r="5" fill={color} />
+      </svg>
+    ),
+    'traffic-moderate': (
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} style={{ display: 'block' }}>
+        <circle cx="6" cy="6" r="5" fill={color} />
+      </svg>
+    ),
+    'traffic-light': (
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} style={{ display: 'block' }}>
+        <circle cx="6" cy="6" r="5" fill={color} />
+      </svg>
+    ),
   };
 
   // Wrap icon in container div with fixed dimensions
   return (
     <div style={containerStyle} className={className}>
-      {icons[name] || null}
+      {icons[name] ?? (() => {
+        const normalized = name.toUpperCase().replace(/-/g, '_');
+        const path = (ICON_SVGS as Record<string, string>)[normalized];
+        if (path) {
+          return <img src={path} alt="" style={{ display: 'block', width: '100%', height: '100%' }} />;
+        }
+        return null;
+      })()}
     </div>
   );
 }

--- a/src/lib/icons/index.ts
+++ b/src/lib/icons/index.ts
@@ -53,6 +53,8 @@ export const COLORS = {
   // Background colors
   BACKGROUND_01: '#FFFFFF',
   BACKGROUND_02: '#FFFFFF',
+  // Muted background used for panels/sections
+  BACKGROUND_MUTED: '#F1F1F1',
   
   // Text colors
   TEXT_PRIMARY: '#141414',


### PR DESCRIPTION
Summary:
- Extracted shared advice primitives and refactored MetaItem, MetaItemAd, Interesting, Cover, RD
- Unified icon system: Icon.tsx now uses inline SVGs + ICON_SVGS fallback; added traffic icons
- Consolidated bg-[#F1F1F1] to a centralized token and applied across Dashboard/AdviceSection/test-advice
- Added CLEANUP_PLAN.md for broader repo cleanup

Notes:
- No breaking changes to public component APIs
- Lints are clean