### PR TITLE
feat: implement AddressPage, MasterDetailsPage, and MastersListPage w…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,35 @@ This application follows **Atomic Design** methodology with a clear component hi
 
 ```
 src/
-├── app/                    # Next.js app router
+├── app/                       # Next.js app router
 ├── components/
-│   ├── atoms/             # Basic UI elements (Button, Badge, Text, Icon)
-│   ├── molecules/         # Combinations of atoms (SearchResultItem, QuickAction)
-│   ├── organisms/         # Complex components (SearchBar, SearchResultsList, BottomSheet)
-│   ├── templates/         # Page layouts (MobileMapShell, ScreenRenderer)
-│   └── pages/            # Full pages (DashboardPage, SearchResultsPage)
-├── stores/                # Zustand state management
-│   ├── index.ts          # Main store with middleware
-│   ├── slices/           # Map, Search, UI state slices
-│   ├── selectors/        # Atomic selectors for performance
-│   └── types.ts          # TypeScript interfaces
+│   ├── atoms/                # Basic UI elements (Button, Icon, FilterChip, RatingStars)
+│   ├── molecules/            # Combinations of atoms (SearchInput, FriendAvatars, OrganizationTabs)
+│   ├── organisms/            # Complex components (SearchBar, OrganizationHeader, MastersNearbyCard)
+│   ├── templates/            # Page layouts (MobileMapShell, ScreenRenderer)
+│   └── pages/               # Full pages (DashboardPage, OrganizationPage)
+├── stores/                   # Zustand state management
+│   ├── index.ts             # Main store with middleware
+│   ├── slices/              # Map, Search, UI, Organization state slices
+│   │   ├── mapSlice.ts
+│   │   ├── searchSlice.ts
+│   │   ├── uiSlice.ts
+│   │   ├── organizationSlice.ts
+│   │   └── actions.ts       # Cross-slice actions
+│   ├── selectors/           # Atomic selectors for performance
+│   └── types.ts             # TypeScript interfaces
 ├── lib/
 │   └── ui/
-│       └── tokens.ts     # Design tokens (colors, spacing, typography)
-├── __mocks__/            # Mock data for development
-└── assets/               # Static assets (images, icons)
+│       └── tokens.ts        # Design tokens (colors, spacing, typography)
+├── __mocks__/               # Mock data for development
+│   ├── search/              # Search results and suggestions
+│   └── masters/             # Service professionals data
+├── assets/                  # Static assets and Figma exports
+│   └── figma/               # Extracted Figma assets
+└── public/
+    ├── avatars/             # Friend avatars from Figma
+    ├── assets/              # Product images and icons
+    └── icons/               # UI icons
 ```
 
 ## 🎨 Design Principles
@@ -135,6 +147,7 @@ Simple combinations of atoms (recently migrated to atomic design):
 - `SearchHistoryItem` - Search history items following SuggestRow pattern
 - `FriendAvatars` - Overlapping avatar display with pixel-perfect Figma specs (24×24px, 50% overlap)
 - `ZMKBlock` - Purple gradient advertising block for non-advertiser search results
+- `OrganizationTabs` - Horizontal scrollable tabs with counters and gradients
 
 ### Organisms
 Complex, self-contained components:
@@ -146,6 +159,8 @@ Complex, self-contained components:
 - `SearchHistorySection` - Search history with default suggestions for new users
 - `CityHighlightsSection` - Featured city content using Cover molecule
 - `SearchResultCard` - Complete search result display with friends integration and ZMK advertising
+- `OrganizationHeader` - Organization page header with expanded/collapsed states
+- `MastersNearbyCard` - Service professionals with ratings and galleries
 
 ### Templates
 Page layouts and navigation:
@@ -157,6 +172,7 @@ Complete screen implementations:
 - `DashboardPage` - Home screen with advice cards
 - `SearchResultsPage` - Search results display
 - `SearchSuggestionsPage` - Search suggestions with empty search state (recommendations, history, city highlights)
+- `OrganizationPage` - Complete organization details with tabs navigation
 
 ## 🏪 State Management
 
@@ -173,7 +189,8 @@ const actions = useActions();
 - **Map Slice**: Map instance, markers, center, zoom with direct map control
 - **Search Slice**: Query, suggestions, results, history with debounced search
 - **UI Slice**: Navigation, bottom sheet, screen state with optimized updates
-- **Cross-Slice Actions**: Coordinated workflows like `performSearch()`
+- **Organization Slice**: Organization details, tab navigation, loading states
+- **Cross-Slice Actions**: Coordinated workflows like `performSearch()`, `selectOrganization()`
 
 ### Performance Features
 - **Selective Re-renders**: Components only update when their data changes
@@ -183,11 +200,13 @@ const actions = useActions();
 
 ## 🎯 Key Features
 
-- **Draggable Bottom Sheet** - 3 snap points (10%, 50%, 90%) with state persistence
+- **Draggable Bottom Sheet** - Smart auto-expansion: search pages open at 90%, dashboard at 50%
 - **Interactive Map** - 2GIS MapGL with markers and navigation, direct control
 - **Smart Search System** - Real-time suggestions, debounced queries, cached results
 - **Search Results with Social Features** - Friends visited indicators with overlapping avatars
 - **Empty Search State** - Complete UX with recommendations, history, and city highlights
+- **Organization Details** - Complete organization pages with tabs navigation and content sections
+- **Service Professionals** - MastersNearbyCard with ratings, galleries, and contact information
 - **Advice Cards System** - Masonry grid with MetaItem, Cover, Interesting, RD components
 - **Atomic Design Architecture** - Recently migrated to strict component hierarchy
 - **Design Tokens** - Centralized styling system with no hardcoded values

--- a/src/__mocks__/masters/data.ts
+++ b/src/__mocks__/masters/data.ts
@@ -1,0 +1,176 @@
+export interface Review {
+  id: string;
+  customerName: string;
+  date: string;
+  rating: number;
+  text: string;
+}
+
+export interface Master {
+  id: string;
+  name: string;
+  profession: string;
+  description: string;
+  rating: number;
+  reviewCount: number;
+  photo: string;
+  yearsOfExperience?: number;
+  completedJobs?: number;
+  phone?: string;
+  reviews?: Review[];
+}
+
+export const mockMasters: Master[] = [
+  {
+    id: 'master-1',
+    name: 'Елена Петрова',
+    profession: 'Маникюр, педикюр',
+    description: 'Опытный мастер маникюра с 8-летним стажем. Качественное покрытие гель-лаком.',
+    rating: 4.9,
+    reviewCount: 127,
+    photo: '/avatars/23edad0153988d6704197a43ed4d17e51f00e455.png',
+    yearsOfExperience: 8,
+    completedJobs: 1250,
+    phone: '+7 (913) 123-45-67',
+    reviews: [
+      {
+        id: 'review-1-1',
+        customerName: 'Анна К.',
+        date: '2 дня назад',
+        rating: 5,
+        text: 'Отличный мастер! Быстро и качественно сделала маникюр. Покрытие держится уже две недели без сколов.'
+      },
+      {
+        id: 'review-1-2',
+        customerName: 'Мария С.',
+        date: '1 неделя назад',
+        rating: 5,
+        text: 'Елена - профессионал своего дела. Аккуратно работает, стерильные инструменты. Обязательно вернусь!'
+      },
+      {
+        id: 'review-1-3',
+        customerName: 'Ольга Д.',
+        date: '2 недели назад',
+        rating: 4,
+        text: 'Хорошая работа, но немного долго делала. В остальном всё отлично, результатом довольна.'
+      }
+    ],
+  },
+  {
+    id: 'master-2',
+    name: 'Анна Смирнова',
+    profession: 'Аппаратный маникюр',
+    description: 'Специализируюсь на аппаратном маникюре и укреплении ногтей.',
+    rating: 4.8,
+    reviewCount: 89,
+    photo: '/avatars/7c555ac081e621955c2c245891b952413a9a27c3.png',
+    yearsOfExperience: 5,
+    completedJobs: 980,
+    phone: '+7 (913) 234-56-78',
+    reviews: [
+      {
+        id: 'review-2-1',
+        customerName: 'Светлана П.',
+        date: '3 дня назад',
+        rating: 5,
+        text: 'Анна замечательный мастер! Аппаратный маникюр сделала идеально, кутикула убрана без повреждений.'
+      },
+      {
+        id: 'review-2-2',
+        customerName: 'Екатерина В.',
+        date: '1 неделя назад',
+        rating: 4,
+        text: 'Хорошо работает с проблемными ногтями. Качественно укрепила мои слабые ногти.'
+      }
+    ],
+  },
+  {
+    id: 'master-3',
+    name: 'Ольга Иванова',
+    profession: 'Nail art специалист',
+    description: 'Создаю уникальные дизайны ногтей. Художественная роспись и стемпинг.',
+    rating: 5.0,
+    reviewCount: 156,
+    photo: '/avatars/5becee8b64e742d845f3d3853a20fc8aa217f421.png',
+  },
+  {
+    id: 'master-4',
+    name: 'Мария Козлова',
+    profession: 'Маникюр и дизайн',
+    description: 'Комплексный уход за ногтями и кожей рук. Современные техники дизайна.',
+    rating: 4.7,
+    reviewCount: 203,
+    photo: '/avatars/3f7bea47f4117b52225de7a6e196c4397746c1aa.png',
+  },
+  {
+    id: 'master-5',
+    name: 'Сергей Михайлов',
+    profession: 'Электрик',
+    description: 'Монтаж и ремонт электропроводки. Установка розеток, выключателей, светильников.',
+    rating: 4.9,
+    reviewCount: 78,
+    photo: '/avatars/23edad0153988d6704197a43ed4d17e51f00e455.png',
+    yearsOfExperience: 12,
+    completedJobs: 560,
+    phone: '+7 (913) 456-78-90',
+    reviews: [
+      {
+        id: 'review-5-1',
+        customerName: 'Александр И.',
+        date: '4 дня назад',
+        rating: 5,
+        text: 'Отличный электрик! Быстро нашёл проблему с проводкой и качественно всё починил. Работает аккуратно.'
+      },
+      {
+        id: 'review-5-2',
+        customerName: 'Наталья К.',
+        date: '1 неделя назад',
+        rating: 5,
+        text: 'Сергей установил дополнительные розетки в кухне. Работа выполнена профессионально, убрал за собой.'
+      },
+      {
+        id: 'review-5-3',
+        customerName: 'Дмитрий Ф.',
+        date: '2 недели назад',
+        rating: 4,
+        text: 'Хороший мастер, знает своё дело. Немного задержался по времени, но работу сделал качественно.'
+      }
+    ],
+  },
+  {
+    id: 'master-6',
+    name: 'Александр Волков',
+    profession: 'Сантехник',
+    description: 'Ремонт и установка сантехники. Устранение протечек, замена смесителей.',
+    rating: 4.8,
+    reviewCount: 145,
+    photo: '/avatars/7c555ac081e621955c2c245891b952413a9a27c3.png',
+  },
+  {
+    id: 'master-7',
+    name: 'Татьяна Николаева',
+    profession: 'Массажист',
+    description: 'Классический и лечебный массаж. Снятие мышечного напряжения и стресса.',
+    rating: 4.9,
+    reviewCount: 92,
+    photo: '/avatars/5becee8b64e742d845f3d3853a20fc8aa217f421.png',
+  },
+];
+
+// Helper functions
+export function getMastersByProfession(profession: string): Master[] {
+  return mockMasters.filter(master => 
+    master.profession.toLowerCase().includes(profession.toLowerCase())
+  );
+}
+
+export function getTopRatedMasters(limit: number = 5): Master[] {
+  return [...mockMasters]
+    .sort((a, b) => b.rating - a.rating)
+    .slice(0, limit);
+}
+
+export function getRandomMasters(count: number = 3): Master[] {
+  const shuffled = [...mockMasters].sort(() => 0.5 - Math.random());
+  return shuffled.slice(0, count);
+}

--- a/src/__mocks__/search/results.ts
+++ b/src/__mocks__/search/results.ts
@@ -23,6 +23,8 @@ export interface SearchResult {
     displayText?: string;
   };
   coords?: [number, number];
+  // Result type to distinguish between organizations and addresses
+  type?: 'organization' | 'address';
   hasLogo?: boolean;
   hasPhotos?: boolean;
   isAdvertiser?: boolean;
@@ -46,12 +48,23 @@ export interface SearchResult {
  * Comprehensive data with varied states for testing UI components
  */
 export const mockSearchResults: SearchResult[] = [
+  // Add address result example
+  {
+    id: 'address-1',
+    name: 'Ленина 11',
+    category: 'Жилое здание',
+    address: 'ул. Ленина 11, Новосибирск',
+    distance: '2 мин',
+    type: 'address',
+    coords: [82.9207, 55.0415],
+  },
   {
     id: '1',
     name: 'Управление ГИБДД',
     category: 'Главное управление МВД России по Новосибирской области',
     address: 'Тверская 32/12, 1 этаж, Москва',
     distance: '3 мин',
+    type: 'organization',
     closingStatus: {
       text: 'Закроется через 30 минут',
       isWarning: true,
@@ -66,6 +79,7 @@ export const mockSearchResults: SearchResult[] = [
     reviewCount: 120,
     address: 'ул. Ленина 45, Новосибирск',
     distance: '3 мин',
+    type: 'organization',
     coords: [82.9307, 55.0515],
     isAdvertiser: true,
     logo: '/icons/eae313a48883a46e7a2a60ee806e73a8052191be.png',
@@ -101,6 +115,7 @@ export const mockSearchResults: SearchResult[] = [
     reviewCount: 89,
     address: 'пр. Дзержинского 12, 2 этаж, Новосибирск',
     distance: '850 м',
+    type: 'organization',
     isAdvertiser: false,
     closingStatus: {
       text: 'Работает до 20:00',
@@ -129,6 +144,37 @@ export const mockSearchResults: SearchResult[] = [
     },
     coords: [82.9407, 55.0615],
   },
+];
+
+// Mock address results for fallback search
+export const mockAddressResults: SearchResult[] = [
+  {
+    id: 'addr-lenin-11-fallback',
+    name: 'ул. Ленина, 11',
+    category: 'Жилое здание',
+    address: 'ул. Ленина, 11, Новосибирск',
+    distance: '250 м',
+    type: 'address',
+    coords: [82.9207, 55.0415],
+  },
+  {
+    id: 'addr-tverskaya-15',
+    name: 'ул. Тверская, 15',
+    category: 'Административное здание',
+    address: 'ул. Тверская, 15, Москва',
+    distance: '800 м',
+    type: 'address',
+    coords: [37.6173, 55.7558],
+  },
+  {
+    id: 'addr-mira-45',
+    name: 'пр. Мира, 45',
+    category: 'Торговый центр',
+    address: 'пр. Мира, 45, Новосибирск',
+    distance: '1.2 км',
+    type: 'address',
+    coords: [82.9307, 55.0515],
+  }
 ];
 
 export const mockRestaurantResults: SearchResult[] = [
@@ -202,6 +248,7 @@ export const manySearchResults: SearchResult[] = [
   ...mockSearchResults,
   ...mockRestaurantResults,
   ...mockCafeResults,
+  ...mockAddressResults,
 ];
 
 // Helper function to generate search results

--- a/src/components/molecules/AddressTabs.tsx
+++ b/src/components/molecules/AddressTabs.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import React from 'react';
+import { tokens } from '@/lib/ui/tokens';
+
+export interface TabItem {
+  id: string;
+  label: string;
+  count?: number;
+}
+
+interface AddressTabsProps {
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+  tabs: TabItem[];
+  className?: string;
+}
+
+/**
+ * AddressTabs Molecule
+ * Simplified tab navigation component for address detail page
+ * 
+ * Features:
+ * - Same styling as OrganizationTabs but simplified structure
+ * - Only "Обзор" and "Мастера" tabs for addresses
+ * - Active tab: White background with shadow
+ * - Inactive tabs: Gray text, transparent background
+ * - Horizontal scrollable layout with fade mask edges
+ */
+export function AddressTabs({
+  activeTab,
+  onTabChange,
+  tabs,
+  className = '',
+}: AddressTabsProps) {
+  return (
+    <div className={`relative ${className}`}>
+      {/* Fade mask overlay */}
+      <div className="absolute bottom-0 left-0 right-0 top-0 pointer-events-none z-10">
+        {/* Right gradient fade */}
+        <div 
+          className="absolute bottom-0 right-0 top-0 w-5"
+          style={{
+            background: 'linear-gradient(to left, rgba(255,255,255,0) 5.625%, rgba(255,255,255,1) 100%)',
+          }}
+        />
+        {/* Left gradient fade */}
+        <div 
+          className="absolute bottom-0 left-0 top-0 w-5"
+          style={{
+            background: 'linear-gradient(to right, rgba(255,255,255,0) 5.625%, rgba(255,255,255,1) 100%)',
+          }}
+        />
+      </div>
+
+      {/* Tabs container */}
+      <div className="flex flex-row gap-0.5 items-start justify-start px-4 py-3 overflow-x-auto scrollbar-hide">
+        {tabs.map((tab) => {
+          const isActive = tab.id === activeTab;
+          
+          return (
+            <button
+              key={tab.id}
+              onClick={() => onTabChange(tab.id)}
+              className={`
+                flex flex-row items-center gap-1.5 rounded-lg shrink-0 transition-all duration-200
+                ${isActive 
+                  ? 'bg-white shadow-[0px_0px_0px_0.5px_rgba(0,0,0,0.04),0px_1px_4px_0px_rgba(0,0,0,0.08)]' 
+                  : 'bg-transparent'
+                }
+              `}
+              style={{
+                paddingLeft: tokens.spacing[3], // 12px
+                paddingRight: tab.count ? '10px' : tokens.spacing[3], // 10px or 12px
+                paddingTop: '9px',
+                paddingBottom: '9px',
+              }}
+            >
+              {/* Tab label */}
+              <span
+                className="font-medium text-left text-nowrap"
+                style={{
+                  color: isActive ? tokens.colors.text.primary : tokens.colors.text.secondary,
+                  fontSize: tokens.typography.fontSize.base, // 14px
+                  lineHeight: '18px',
+                  letterSpacing: '-0.28px',
+                  fontFamily: 'SB Sans Text, sans-serif',
+                }}
+              >
+                {tab.label}
+              </span>
+
+              {/* Counter badge - same as OrganizationTabs */}
+              {tab.count && (
+                <div className="flex flex-row h-[18px] items-end justify-start">
+                  <div className="flex flex-col items-start justify-start overflow-hidden rounded-xl">
+                    <div 
+                      className="flex flex-col items-center justify-center rounded-xl"
+                      style={{
+                        backgroundColor: 'rgba(20,20,20,0.3)',
+                        paddingTop: '1px',
+                        paddingBottom: '2px',
+                        paddingLeft: '5px',
+                        paddingRight: '5px',
+                        minWidth: '9px',
+                      }}
+                    >
+                      <span
+                        className="font-medium text-center text-nowrap"
+                        style={{
+                          color: tokens.colors.text.inverse, // #FFFFFF
+                          fontSize: '13px',
+                          lineHeight: '16px',
+                          letterSpacing: '-0.234px',
+                          fontFamily: 'SB Sans Text, sans-serif',
+                        }}
+                      >
+                        {tab.count}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/molecules/MasterCard.tsx
+++ b/src/components/molecules/MasterCard.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import { tokens } from '@/lib/ui/tokens';
+import { Text, RatingStars, Button } from '@/components/atoms';
+import { useActions } from '@/stores';
+import type { Master } from '@/__mocks__/masters/data';
+
+interface MasterCardProps {
+  master: Master;
+  onClick?: (master: Master) => void;
+  className?: string;
+}
+
+/**
+ * MasterCard Molecule
+ * Professional service master card with photo, info, and action button
+ * 
+ * Features:
+ * - Left: Master photo (80x80px rounded)
+ * - Center: Name, profession, description, rating
+ * - Right: "Подробнее" button
+ * - Clean, professional styling with good visual hierarchy
+ */
+export function MasterCard({ 
+  master, 
+  onClick,
+  className = '' 
+}: MasterCardProps) {
+  const actions = useActions();
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick(master);
+    } else {
+      // Default behavior: navigate to master details
+      actions.selectMaster(master);
+    }
+  };
+
+  return (
+    <div
+      className={`master-card ${className}`}
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        justifyContent: 'space-between',
+        padding: tokens.spacing[4], // 16px
+        gap: tokens.spacing[3], // 12px
+        width: '100%',
+        boxSizing: 'border-box',
+      }}
+    >
+      {/* Master Photo - Left */}
+      <div className="w-16 h-16 flex-shrink-0 overflow-hidden rounded-full">
+        <Image
+          src={master.photo}
+          alt={`${master.name} - ${master.profession}`}
+          width={64}
+          height={64}
+          className="w-full h-full object-cover"
+          style={{
+            backgroundColor: tokens.colors.background.secondary,
+          }}
+        />
+      </div>
+
+      {/* Master Info - Center */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          minWidth: 0,
+          gap: tokens.spacing[1], // 4px
+        }}
+      >
+        {/* Name */}
+        <Text
+          as="h3"
+          style={{
+            fontSize: tokens.typography.fontSize.lg, // 16px
+            fontWeight: tokens.typography.fontWeight.semibold, // 600
+            color: tokens.colors.text.primary,
+            lineHeight: '20px',
+            margin: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {master.name}
+        </Text>
+
+        {/* Profession */}
+        <Text
+          as="p"
+          style={{
+            fontSize: tokens.typography.fontSize.sm, // 12px
+            fontWeight: tokens.typography.fontWeight.medium, // 500
+            color: tokens.colors.text.secondary,
+            lineHeight: '16px',
+            margin: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {master.profession}
+        </Text>
+
+        {/* Description */}
+        <Text
+          as="p"
+          style={{
+            fontSize: tokens.typography.fontSize.sm, // 12px
+            fontWeight: tokens.typography.fontWeight.normal, // 400
+            color: tokens.colors.text.secondary,
+            lineHeight: '16px',
+            margin: 0,
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {master.description}
+        </Text>
+
+        {/* Rating */}
+        <div
+          style={{
+            marginTop: tokens.spacing[1], // 4px
+          }}
+        >
+          <RatingStars
+            rating={master.rating}
+            reviewCount={master.reviewCount}
+            showNumber={true}
+            theme="Light"
+            size={14}
+          />
+        </div>
+      </div>
+
+      {/* Action Button - Right */}
+      <div
+        style={{
+          flexShrink: 0,
+          alignSelf: 'center',
+        }}
+      >
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={handleClick}
+          style={{
+            fontSize: tokens.typography.fontSize.sm, // 12px
+            fontWeight: tokens.typography.fontWeight.medium, // 500
+            padding: `${tokens.spacing[2]} ${tokens.spacing[3]}`, // 8px 12px
+            borderRadius: tokens.borders.radius.md, // 8px
+            backgroundColor: tokens.colors.background.secondary,
+            color: tokens.colors.text.primary,
+            border: 'none',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          Подробнее
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/molecules/ReviewCard.tsx
+++ b/src/components/molecules/ReviewCard.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React from 'react';
+import { tokens } from '@/lib/ui/tokens';
+import { Text, RatingStars } from '@/components/atoms';
+
+export interface Review {
+  id: string;
+  customerName: string;
+  date: string;
+  rating: number;
+  text: string;
+}
+
+interface ReviewCardProps {
+  review: Review;
+  className?: string;
+}
+
+/**
+ * ReviewCard Molecule
+ * Displays a customer review with name, date, rating, and review text
+ * 
+ * Features:
+ * - Customer name and date in header
+ * - Star rating display
+ * - Review text with proper line breaks
+ * - Clean, readable layout with proper spacing
+ */
+export function ReviewCard({ 
+  review, 
+  className = '' 
+}: ReviewCardProps) {
+  return (
+    <div
+      className={`review-card ${className}`}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: tokens.colors.background.primary,
+        borderRadius: tokens.borders.radius.lg,
+        padding: tokens.spacing[4], // 16px
+        gap: tokens.spacing[2], // 8px
+        width: '100%',
+        boxSizing: 'border-box',
+      }}
+    >
+      {/* Header - Name and Date */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          width: '100%',
+        }}
+      >
+        <Text
+          as="h4"
+          style={{
+            fontSize: tokens.typography.fontSize.base, // 14px
+            fontWeight: tokens.typography.fontWeight.semibold, // 600
+            color: tokens.colors.text.primary,
+            lineHeight: '18px',
+            margin: 0,
+          }}
+        >
+          {review.customerName}
+        </Text>
+        
+        <Text
+          as="span"
+          style={{
+            fontSize: tokens.typography.fontSize.sm, // 12px
+            fontWeight: tokens.typography.fontWeight.normal, // 400
+            color: tokens.colors.text.secondary,
+            lineHeight: '16px',
+            margin: 0,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {review.date}
+        </Text>
+      </div>
+
+      {/* Rating */}
+      <div>
+        <RatingStars
+          rating={review.rating}
+          showNumber={false}
+          theme="Light"
+          size={16}
+        />
+      </div>
+
+      {/* Review Text */}
+      <Text
+        as="p"
+        style={{
+          fontSize: tokens.typography.fontSize.base, // 14px
+          fontWeight: tokens.typography.fontWeight.normal, // 400
+          color: tokens.colors.text.primary,
+          lineHeight: '20px',
+          margin: 0,
+          whiteSpace: 'pre-wrap', // Preserve line breaks
+        }}
+      >
+        {review.text}
+      </Text>
+    </div>
+  );
+}

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -25,3 +25,6 @@ export { ZMKBlock } from './ZMKBlock';
 
 // Organization Molecules
 export { OrganizationTabs, type TabItem } from './OrganizationTabs';
+export { AddressTabs } from './AddressTabs';
+export { MasterCard } from './MasterCard';
+export { ReviewCard, type Review } from './ReviewCard';

--- a/src/components/organisms/MasterDetailsHeader.tsx
+++ b/src/components/organisms/MasterDetailsHeader.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import { tokens } from '@/lib/ui/tokens';
+import { Text, RatingStars, Button } from '@/components/atoms';
+import type { Master } from '@/__mocks__/masters/data';
+
+interface MasterDetailsHeaderProps {
+  master: Master;
+  onBackClick?: () => void;
+  className?: string;
+}
+
+/**
+ * MasterDetailsHeader Organism
+ * Header for master details page with large photo, info, and back button
+ * 
+ * Features:
+ * - Large circular master photo (120x120px)
+ * - Master name, profession, and rating
+ * - Years of experience and completed jobs stats
+ * - Back button for navigation
+ * - Clean, professional layout
+ */
+export function MasterDetailsHeader({ 
+  master, 
+  onBackClick,
+  className = '' 
+}: MasterDetailsHeaderProps) {
+  return (
+    <div
+      className={`master-details-header ${className}`}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        backgroundColor: tokens.colors.background.primary,
+        padding: `${tokens.spacing[6]} ${tokens.spacing[4]}`, // 24px vertical, 16px horizontal
+        position: 'relative',
+        width: '100%',
+        boxSizing: 'border-box',
+      }}
+    >
+      {/* Back Button - Top Left */}
+      {onBackClick && (
+        <div
+          style={{
+            position: 'absolute',
+            top: tokens.spacing[4], // 16px
+            left: tokens.spacing[4], // 16px
+            zIndex: 10,
+          }}
+        >
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onBackClick}
+            style={{
+              padding: tokens.spacing[2], // 8px
+              borderRadius: tokens.borders.radius.full,
+              backgroundColor: 'rgba(20, 20, 20, 0.06)',
+              color: tokens.colors.text.primary,
+              border: 'none',
+              width: '40px',
+              height: '40px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            ←
+          </Button>
+        </div>
+      )}
+
+      {/* Master Photo - Large Circle */}
+      <div
+        className="flex-shrink-0 overflow-hidden rounded-full"
+        style={{
+          width: '120px',
+          height: '120px',
+          marginBottom: tokens.spacing[4], // 16px
+        }}
+      >
+        <Image
+          src={master.photo}
+          alt={`${master.name} - ${master.profession}`}
+          width={120}
+          height={120}
+          className="w-full h-full object-cover"
+          style={{
+            backgroundColor: tokens.colors.background.secondary,
+          }}
+        />
+      </div>
+
+      {/* Master Name */}
+      <Text
+        as="h1"
+        style={{
+          fontSize: tokens.typography.fontSize.xl, // 18px
+          fontWeight: tokens.typography.fontWeight.semibold, // 600
+          color: tokens.colors.text.primary,
+          lineHeight: '24px',
+          margin: 0,
+          marginBottom: tokens.spacing[1], // 4px
+          textAlign: 'center',
+        }}
+      >
+        {master.name}
+      </Text>
+
+      {/* Profession */}
+      <Text
+        as="p"
+        style={{
+          fontSize: tokens.typography.fontSize.base, // 14px
+          fontWeight: tokens.typography.fontWeight.normal, // 400
+          color: tokens.colors.text.secondary,
+          lineHeight: '18px',
+          margin: 0,
+          marginBottom: tokens.spacing[3], // 12px
+          textAlign: 'center',
+        }}
+      >
+        {master.profession}
+      </Text>
+
+      {/* Rating */}
+      <div
+        style={{
+          marginBottom: tokens.spacing[4], // 16px
+        }}
+      >
+        <RatingStars
+          rating={master.rating}
+          reviewCount={master.reviewCount}
+          showNumber={true}
+          theme="Light"
+          size={20}
+        />
+      </div>
+
+      {/* Stats Row */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: tokens.spacing[6], // 24px
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+        }}
+      >
+        {/* Years of Experience */}
+        {master.yearsOfExperience && (
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: tokens.spacing[1], // 4px
+            }}
+          >
+            <Text
+              as="span"
+              style={{
+                fontSize: tokens.typography.fontSize.lg, // 16px
+                fontWeight: tokens.typography.fontWeight.semibold, // 600
+                color: tokens.colors.text.primary,
+                lineHeight: '20px',
+                margin: 0,
+              }}
+            >
+              {master.yearsOfExperience}
+            </Text>
+            <Text
+              as="span"
+              style={{
+                fontSize: tokens.typography.fontSize.sm, // 12px
+                fontWeight: tokens.typography.fontWeight.normal, // 400
+                color: tokens.colors.text.secondary,
+                lineHeight: '16px',
+                margin: 0,
+                textAlign: 'center',
+              }}
+            >
+              {master.yearsOfExperience === 1 ? 'год опыта' : 
+               master.yearsOfExperience < 5 ? 'года опыта' : 'лет опыта'}
+            </Text>
+          </div>
+        )}
+
+        {/* Completed Jobs */}
+        {master.completedJobs && (
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: tokens.spacing[1], // 4px
+            }}
+          >
+            <Text
+              as="span"
+              style={{
+                fontSize: tokens.typography.fontSize.lg, // 16px
+                fontWeight: tokens.typography.fontWeight.semibold, // 600
+                color: tokens.colors.text.primary,
+                lineHeight: '20px',
+                margin: 0,
+              }}
+            >
+              {master.completedJobs}
+            </Text>
+            <Text
+              as="span"
+              style={{
+                fontSize: tokens.typography.fontSize.sm, // 12px
+                fontWeight: tokens.typography.fontWeight.normal, // 400
+                color: tokens.colors.text.secondary,
+                lineHeight: '16px',
+                margin: 0,
+                textAlign: 'center',
+              }}
+            >
+              выполненных{'\n'}работ
+            </Text>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/organisms/MastersList.tsx
+++ b/src/components/organisms/MastersList.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import React from 'react';
+import { tokens } from '@/lib/ui/tokens';
+import { Text } from '@/components/atoms';
+import { MasterCard } from '@/components/molecules';
+import type { Master } from '@/__mocks__/masters/data';
+
+interface MastersListProps {
+  masters: Master[];
+  onMasterClick?: (master: Master) => void;
+  className?: string;
+  title?: string;
+  emptyMessage?: string;
+}
+
+/**
+ * MastersList Organism
+ * Renders a vertical list of master cards with proper spacing
+ * 
+ * Features:
+ * - Vertical scrollable list layout
+ * - Optional title and empty state message
+ * - Consistent spacing between cards
+ * - Handles master selection via onClick
+ */
+export function MastersList({
+  masters,
+  onMasterClick,
+  className = '',
+  title,
+  emptyMessage = 'Мастеров пока нет'
+}: MastersListProps) {
+  const handleMasterClick = (master: Master) => {
+    if (onMasterClick) {
+      onMasterClick(master);
+    }
+  };
+
+  return (
+    <div
+      className={`masters-list ${className}`}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+      }}
+    >
+      {/* Title */}
+      {title && (
+        <Text
+          as="h2"
+          style={{
+            fontSize: tokens.typography.fontSize.xl, // 18px
+            fontWeight: tokens.typography.fontWeight.semibold, // 600
+            color: tokens.colors.text.primary,
+            lineHeight: '24px',
+            margin: 0,
+            marginBottom: tokens.spacing[4], // 16px
+          }}
+        >
+          {title}
+        </Text>
+      )}
+
+      {/* Masters List */}
+      {masters.length > 0 ? (
+        <div
+          style={{
+            backgroundColor: tokens.colors.background.secondary, // Gray background
+            borderRadius: tokens.borders.radius.lg,
+            padding: tokens.spacing[4], // 16px padding around the list
+            width: '100%',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: tokens.spacing[3], // 12px between cards
+              width: '100%',
+            }}
+          >
+            {masters.map((master) => (
+              <div
+                key={master.id}
+                style={{
+                  backgroundColor: tokens.colors.background.primary, // White card background
+                  borderRadius: tokens.borders.radius.lg,
+                  overflow: 'hidden', // Ensure rounded corners are respected
+                }}
+              >
+                <MasterCard
+                  master={master}
+                  onClick={handleMasterClick}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: `${tokens.spacing[8]} ${tokens.spacing[4]}`, // 32px 16px
+            backgroundColor: tokens.colors.background.secondary,
+            borderRadius: tokens.borders.radius.lg,
+          }}
+        >
+          <Text
+            as="p"
+            style={{
+              fontSize: tokens.typography.fontSize.base, // 14px
+              fontWeight: tokens.typography.fontWeight.normal, // 400
+              color: tokens.colors.text.secondary,
+              textAlign: 'center',
+              margin: 0,
+            }}
+          >
+            {emptyMessage}
+          </Text>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/organisms/SearchResultCard.tsx
+++ b/src/components/organisms/SearchResultCard.tsx
@@ -39,6 +39,9 @@ export interface SearchResultCardProps {
   zmkData?: {
     products: ZMKProduct[];
   };
+  coords?: [number, number];
+  // Result type to distinguish between organizations and addresses
+  type?: 'organization' | 'address';
   // Advertiser-specific fields
   isAdvertiser?: boolean;
   logo?: string;

--- a/src/components/organisms/SearchResultsList.tsx
+++ b/src/components/organisms/SearchResultsList.tsx
@@ -7,6 +7,7 @@ import { Text } from '@/components/atoms';
 import { tokens } from '@/lib/ui/tokens';
 import { mockMastersNearby, mastersNearbyConfig } from '@/__mocks__/masters/nearby';
 import useStore from '@/stores';
+import { useActions } from '@/stores';
 
 interface SearchResultsListProps {
   results: SearchResultCardProps[];
@@ -24,15 +25,16 @@ export function SearchResultsList({
   onResultClick,
   className = '',
 }: SearchResultsListProps) {
-  // Get current search query from Zustand store
+  // Get current search query from Zustand store and actions
   const query = useStore((state) => state.search.query);
+  const actions = useActions();
   
   // Check if we should show Masters Nearby card
   const shouldShowMastersCard = query.toLowerCase().trim() === 'маникюр';
 
   const handleMastersCardClick = () => {
-    console.log('Masters nearby card clicked');
-    // TODO: Navigate to masters page or show masters details
+    // Navigate to masters list page
+    actions.showMastersList();
   };
 
   // Empty state

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -18,6 +18,8 @@ export { MastersNearbyCard } from './MastersNearbyCard';
 
 // Organization Organisms
 export { OrganizationHeader } from './OrganizationHeader';
+export { MastersList } from './MastersList';
+export { MasterDetailsHeader } from './MasterDetailsHeader';
 
 // Layout Organisms
 export { BottomSheet, type BottomSheetProps, type BottomSheetRef } from './bottom-sheet';

--- a/src/components/pages/AddressPage.tsx
+++ b/src/components/pages/AddressPage.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { OrganizationHeader, MastersList } from '@/components/organisms';
+import { AddressTabs, type TabItem } from '@/components/molecules';
+import { tokens } from '@/lib/ui/tokens';
+import useStore from '@/stores';
+import { useActions } from '@/stores';
+import type { SearchResult } from '@/stores/types';
+import { mockMasters } from '@/__mocks__/masters/data';
+import type { Master } from '@/__mocks__/masters/data';
+
+interface AddressPageProps {
+  className?: string;
+}
+
+/**
+ * AddressPage Component
+ * Complete address detail page with header and simplified content sections
+ * 
+ * Features:
+ * - OrganizationHeader reused for addresses (works for both)
+ * - Simplified tabs section with only "Обзор" and "Мастера"
+ * - Content area focused on address-specific information
+ * - Scroll-based header state management
+ */
+export function AddressPage({
+  className = '',
+}: AddressPageProps) {
+  const [isHeaderCollapsed, setIsHeaderCollapsed] = useState(false);
+  
+  // Reuse organization store for addresses - same data structure works
+  const address = useStore((state) => state.organization.currentOrganization);
+  const isLoading = useStore((state) => state.organization.isLoading);
+  const activeTab = useStore((state) => state.organization.activeTab);
+  const setActiveTab = useStore((state) => state.organization.setActiveTab);
+
+  // Simplified tab configuration for addresses
+  const tabs: TabItem[] = [
+    { id: 'overview', label: 'Обзор' },
+    { id: 'masters', label: 'Мастера' },
+  ];
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
+      
+      // Collapse header when scrolled down more than 100px
+      setIsHeaderCollapsed(currentScrollY > 100);
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className={`address-page min-h-full bg-background-secondary flex items-center justify-center ${className}`}>
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">Loading address...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // No address state
+  if (!address) {
+    return (
+      <div className={`address-page min-h-full bg-background-secondary flex items-center justify-center ${className}`}>
+        <div className="text-center">
+          <p className="text-gray-600">Address not found</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`address-page flex flex-col h-full ${className}`}>
+      {/* Header - sticky with no spacing, reuse OrganizationHeader */}
+      <div 
+        className="address-header sticky top-0 z-20 flex-shrink-0 transition-all duration-300"
+        style={{
+          backgroundColor: tokens.colors.background.secondary,
+        }}
+      >
+        <OrganizationHeader 
+          isCollapsed={isHeaderCollapsed}
+        />
+      </div>
+
+      {/* Tabs section - sticky below header with simplified tabs */}
+      <div 
+        className="bg-white border-b sticky flex-shrink-0"
+        style={{
+          top: isHeaderCollapsed ? '64px' : '140px', // Stick below header (approximate heights)
+          zIndex: 10,
+          borderBottomWidth: '1px',
+          borderBottomStyle: 'solid',
+          borderBottomColor: 'rgba(137,137,137,0.3)',
+          transition: 'top 300ms ease-in-out',
+        }}
+      >
+        <AddressTabs
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+          tabs={tabs}
+        />
+      </div>
+
+      {/* Content Area - flex-1 to fill remaining space */}
+      <div 
+        className="bg-white flex-1 overflow-y-auto"
+        style={{
+          padding: tokens.spacing[4],
+          minHeight: '800px', // Make it tall enough to test scrolling
+        }}
+      >
+        {activeTab === 'overview' && <OverviewTabContent address={address} />}
+        {activeTab === 'masters' && <MastersTabContent />}
+      </div>
+    </div>
+  );
+}
+
+// Tab Content Components
+function OverviewTabContent({ address }: { address: SearchResult }) {
+  return (
+    <div className="space-y-6">
+      {/* Address Info Section */}
+      <div>
+        <h2 
+          className="text-lg font-semibold mb-4"
+          style={{
+            color: tokens.colors.text.primary,
+            fontFamily: 'SB Sans Text, sans-serif',
+          }}
+        >
+          Информация об адресе
+        </h2>
+        <div className="space-y-3">
+          <div>
+            <p 
+              className="text-sm font-medium"
+              style={{
+                color: tokens.colors.text.secondary,
+                fontFamily: 'SB Sans Text, sans-serif',
+              }}
+            >
+              Полный адрес
+            </p>
+            <p 
+              className="text-base"
+              style={{
+                color: tokens.colors.text.primary,
+                fontFamily: 'SB Sans Text, sans-serif',
+              }}
+            >
+              {address.address}
+            </p>
+          </div>
+          
+          <div>
+            <p 
+              className="text-sm font-medium"
+              style={{
+                color: tokens.colors.text.secondary,
+                fontFamily: 'SB Sans Text, sans-serif',
+              }}
+            >
+              Тип здания
+            </p>
+            <p 
+              className="text-base"
+              style={{
+                color: tokens.colors.text.primary,
+                fontFamily: 'SB Sans Text, sans-serif',
+              }}
+            >
+              {address.category || 'Жилое здание'}
+            </p>
+          </div>
+
+          {address.distance && (
+            <div>
+              <p 
+                className="text-sm font-medium"
+                style={{
+                  color: tokens.colors.text.secondary,
+                  fontFamily: 'SB Sans Text, sans-serif',
+                }}
+              >
+                Расстояние
+              </p>
+              <p 
+                className="text-base"
+                style={{
+                  color: tokens.colors.text.primary,
+                  fontFamily: 'SB Sans Text, sans-serif',
+                }}
+              >
+                {address.distance}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Building Features Section */}
+      <div>
+        <h2 
+          className="text-lg font-semibold mb-4"
+          style={{
+            color: tokens.colors.text.primary,
+            fontFamily: 'SB Sans Text, sans-serif',
+          }}
+        >
+          Особенности здания
+        </h2>
+        <div className="grid grid-cols-2 gap-3">
+          <div 
+            className="p-3 rounded-lg border"
+            style={{
+              borderColor: 'rgba(137,137,137,0.3)',
+              backgroundColor: tokens.colors.background.primary,
+            }}
+          >
+            <p 
+              className="text-sm font-medium"
+              style={{
+                color: tokens.colors.text.secondary,
+                fontFamily: 'SB Sans Text, sans-serif',
+              }}
+            >
+              Год постройки
+            </p>
+            <p 
+              className="text-base"
+              style={{
+                color: tokens.colors.text.primary,
+                fontFamily: 'SB Sans Text, sans-serif',
+              }}
+            >
+              1995
+            </p>
+          </div>
+          
+          <div 
+            className="p-3 rounded-lg border"
+            style={{
+              borderColor: 'rgba(137,137,137,0.3)',
+              backgroundColor: tokens.colors.background.primary,
+            }}
+          >
+            <p 
+              className="text-sm font-medium"
+              style={{
+                color: tokens.colors.text.secondary,
+                fontFamily: 'SB Sans Text, sans-serif',
+              }}
+            >
+              Этажность
+            </p>
+            <p 
+              className="text-base"
+              style={{
+                color: tokens.colors.text.primary,
+                fontFamily: 'SB Sans Text, sans-serif',
+              }}
+            >
+              9 этажей
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Nearby Organizations Section */}
+      <div>
+        <h2 
+          className="text-lg font-semibold mb-4"
+          style={{
+            color: tokens.colors.text.primary,
+            fontFamily: 'SB Sans Text, sans-serif',
+          }}
+        >
+          Организации в здании
+        </h2>
+        <div className="space-y-3">
+          {['Стоматология "Белые зубы"', 'Салон красоты "Элегант"', 'Офис "Альфа-банк"'].map((org, index) => (
+            <div 
+              key={index}
+              className="p-4 rounded-lg border"
+              style={{
+                borderColor: 'rgba(137,137,137,0.3)',
+                backgroundColor: tokens.colors.background.primary,
+              }}
+            >
+              <p 
+                className="text-base font-medium"
+                style={{
+                  color: tokens.colors.text.primary,
+                  fontFamily: 'SB Sans Text, sans-serif',
+                }}
+              >
+                {org}
+              </p>
+              <p 
+                className="text-sm mt-1"
+                style={{
+                  color: tokens.colors.text.secondary,
+                  fontFamily: 'SB Sans Text, sans-serif',
+                }}
+              >
+                {index === 0 ? '2 этаж' : index === 1 ? '1 этаж' : '3 этаж'}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MastersTabContent() {
+  const actions = useActions();
+  
+  const handleMasterClick = (master: Master) => {
+    // Navigate to master details page
+    actions.selectMaster(master);
+  };
+
+  return (
+    <div>
+      <MastersList
+        masters={mockMasters}
+        onMasterClick={handleMasterClick}
+        title="Мастера поблизости"
+        emptyMessage="Мастера не найдены в этом районе"
+      />
+    </div>
+  );
+}

--- a/src/components/pages/MasterDetailsPage.tsx
+++ b/src/components/pages/MasterDetailsPage.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import React from 'react';
+import { tokens } from '@/lib/ui/tokens';
+import { Text, Button } from '@/components/atoms';
+import { ReviewCard } from '@/components/molecules';
+import { MasterDetailsHeader } from '@/components/organisms';
+import useStore from '@/stores';
+// ScreenType import removed - not used directly in component
+import type { Master } from '@/__mocks__/masters/data';
+
+interface MasterDetailsPageProps {
+  className?: string;
+}
+
+/**
+ * MasterDetailsPage Component
+ * Complete master profile page with header, description, reviews, and call button
+ * 
+ * Features:
+ * - MasterDetailsHeader with large photo and stats
+ * - Master description section
+ * - Reviews list with ReviewCard components
+ * - Fixed call-to-action button at bottom
+ * - Back navigation to previous screen
+ */
+export function MasterDetailsPage({
+  className = '',
+}: MasterDetailsPageProps) {
+  
+  // Get current master from organization slice (reusing for masters)
+  const currentMaster = useStore((state) => state.organization.currentOrganization) as Master | null;
+  
+  const handleBackClick = () => {
+    const ui = useStore.getState().ui;
+    ui.navigateBack();
+  };
+
+  const handleCallClick = () => {
+    if (currentMaster?.phone) {
+      // In a real app, this would initiate a phone call
+      window.location.href = `tel:${currentMaster.phone}`;
+    }
+  };
+
+  // Loading state
+  if (!currentMaster) {
+    return (
+      <div className={`master-details-page min-h-full bg-background-primary flex items-center justify-center ${className}`}>
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">Loading master details...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`master-details-page flex flex-col h-full ${className}`}>
+      {/* Header */}
+      <MasterDetailsHeader 
+        master={currentMaster}
+        onBackClick={handleBackClick}
+      />
+
+      {/* Content Area - Scrollable */}
+      <div 
+        className="flex-1 overflow-y-auto"
+        style={{
+          backgroundColor: tokens.colors.background.secondary,
+          paddingBottom: '80px', // Space for fixed call button
+        }}
+      >
+        <div
+          style={{
+            padding: tokens.spacing[4], // 16px
+          }}
+        >
+          {/* Description Section */}
+          <div
+            style={{
+              backgroundColor: tokens.colors.background.primary,
+              borderRadius: tokens.borders.radius.lg,
+              padding: tokens.spacing[4], // 16px
+              marginBottom: tokens.spacing[4], // 16px
+            }}
+          >
+            <Text
+              as="h2"
+              style={{
+                fontSize: tokens.typography.fontSize.lg, // 16px
+                fontWeight: tokens.typography.fontWeight.semibold, // 600
+                color: tokens.colors.text.primary,
+                lineHeight: '20px',
+                margin: 0,
+                marginBottom: tokens.spacing[3], // 12px
+              }}
+            >
+              О мастере
+            </Text>
+            
+            <Text
+              as="p"
+              style={{
+                fontSize: tokens.typography.fontSize.base, // 14px
+                fontWeight: tokens.typography.fontWeight.normal, // 400
+                color: tokens.colors.text.primary,
+                lineHeight: '20px',
+                margin: 0,
+              }}
+            >
+              {currentMaster.description}
+            </Text>
+          </div>
+
+          {/* Reviews Section */}
+          <div>
+            <Text
+              as="h2"
+              style={{
+                fontSize: tokens.typography.fontSize.lg, // 16px
+                fontWeight: tokens.typography.fontWeight.semibold, // 600
+                color: tokens.colors.text.primary,
+                lineHeight: '20px',
+                margin: 0,
+                marginBottom: tokens.spacing[4], // 16px
+              }}
+            >
+              Отзывы ({currentMaster.reviewCount})
+            </Text>
+
+            {/* Reviews List */}
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: tokens.spacing[3], // 12px
+              }}
+            >
+              {currentMaster.reviews && currentMaster.reviews.length > 0 ? (
+                currentMaster.reviews.map((review) => (
+                  <ReviewCard
+                    key={review.id}
+                    review={review}
+                  />
+                ))
+              ) : (
+                <div
+                  style={{
+                    backgroundColor: tokens.colors.background.primary,
+                    borderRadius: tokens.borders.radius.lg,
+                    padding: `${tokens.spacing[6]} ${tokens.spacing[4]}`, // 24px vertical, 16px horizontal
+                    textAlign: 'center',
+                  }}
+                >
+                  <Text
+                    as="p"
+                    style={{
+                      fontSize: tokens.typography.fontSize.base, // 14px
+                      fontWeight: tokens.typography.fontWeight.normal, // 400
+                      color: tokens.colors.text.secondary,
+                      margin: 0,
+                    }}
+                  >
+                    Отзывов пока нет
+                  </Text>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Fixed Call Button */}
+      {currentMaster.phone && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            backgroundColor: tokens.colors.background.primary,
+            borderTop: `1px solid rgba(137,137,137,0.3)`,
+            padding: tokens.spacing[4], // 16px
+            zIndex: 50,
+          }}
+        >
+          <Button
+            variant="primary"
+            size="lg"
+            onClick={handleCallClick}
+            style={{
+              width: '100%',
+              backgroundColor: '#2563eb', // Primary blue
+              color: 'white',
+              fontSize: tokens.typography.fontSize.lg, // 16px
+              fontWeight: tokens.typography.fontWeight.semibold, // 600
+              padding: `${tokens.spacing[4]} ${tokens.spacing[6]}`, // 16px vertical, 24px horizontal
+              borderRadius: tokens.borders.radius.lg,
+              border: 'none',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: tokens.spacing[2], // 8px
+            }}
+          >
+            📞 Позвонить
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/pages/MastersListPage.tsx
+++ b/src/components/pages/MastersListPage.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import React from 'react';
+import { tokens } from '@/lib/ui/tokens';
+import { Text, Button } from '@/components/atoms';
+import { MastersList } from '@/components/organisms';
+import useStore from '@/stores';
+import { useActions } from '@/stores';
+import { mockMasters } from '@/__mocks__/masters/data';
+import type { Master } from '@/__mocks__/masters/data';
+
+interface MastersListPageProps {
+  className?: string;
+}
+
+/**
+ * MastersListPage Component
+ * Dedicated page showing all nearby masters with navigation
+ * 
+ * Features:
+ * - Simple header with back button
+ * - Full list of masters using MastersList organism
+ * - Gray background with white cards
+ * - Navigation to individual master details
+ * - Back navigation to search results
+ */
+export function MastersListPage({
+  className = '',
+}: MastersListPageProps) {
+  const actions = useActions();
+  
+  const handleBackClick = () => {
+    const ui = useStore.getState().ui;
+    ui.navigateBack();
+  };
+
+  const handleMasterClick = (master: Master) => {
+    // Navigate to master details page
+    actions.selectMaster(master);
+  };
+
+  return (
+    <div className={`masters-list-page flex flex-col h-full ${className}`}>
+      {/* Page Header */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          backgroundColor: tokens.colors.background.primary,
+          padding: `${tokens.spacing[4]} ${tokens.spacing[4]}`, // 16px
+          position: 'relative',
+          borderBottom: `1px solid rgba(137,137,137,0.3)`,
+        }}
+      >
+        {/* Back Button - Left */}
+        <div
+          style={{
+            flexShrink: 0,
+            marginRight: tokens.spacing[3], // 12px
+          }}
+        >
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleBackClick}
+            style={{
+              padding: tokens.spacing[2], // 8px
+              borderRadius: tokens.borders.radius.full,
+              backgroundColor: 'rgba(20, 20, 20, 0.06)',
+              color: tokens.colors.text.primary,
+              border: 'none',
+              width: '40px',
+              height: '40px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            ←
+          </Button>
+        </div>
+
+        {/* Title - Center */}
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+        >
+          <Text
+            as="h1"
+            style={{
+              fontSize: tokens.typography.fontSize.xl, // 18px
+              fontWeight: tokens.typography.fontWeight.semibold, // 600
+              color: tokens.colors.text.primary,
+              lineHeight: '24px',
+              margin: 0,
+              textAlign: 'center',
+            }}
+          >
+            Мастера рядом
+          </Text>
+        </div>
+
+        {/* Right spacer to balance the back button */}
+        <div
+          style={{
+            width: '40px',
+            height: '40px',
+            flexShrink: 0,
+            marginLeft: tokens.spacing[3], // 12px
+          }}
+        />
+      </div>
+
+      {/* Content Area - Scrollable */}
+      <div 
+        className="flex-1 overflow-y-auto"
+        style={{
+          backgroundColor: tokens.colors.background.secondary,
+          padding: tokens.spacing[4], // 16px
+        }}
+      >
+        <MastersList
+          masters={mockMasters}
+          onMasterClick={handleMasterClick}
+          emptyMessage="Мастеров не найдено в этом районе"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/pages/index.ts
+++ b/src/components/pages/index.ts
@@ -2,3 +2,6 @@ export { DashboardPage } from './DashboardPage';
 export { SearchSuggestionsPage } from './SearchSuggestionsPage';
 export { SearchResultsPage } from './SearchResultsPage';
 export { OrganizationPage } from './OrganizationPage';
+export { AddressPage } from './AddressPage';
+export { MasterDetailsPage } from './MasterDetailsPage';
+export { MastersListPage } from './MastersListPage';

--- a/src/components/templates/MobileMapShell.tsx
+++ b/src/components/templates/MobileMapShell.tsx
@@ -74,11 +74,23 @@ export function MobileMapShell({
         targetSnap = 90;
         break;
       case ScreenType.SEARCH_RESULTS:
-        // Set to 50% to show both results and map
-        targetSnap = 50;
+        // Expand to 90% for better visibility of search results
+        targetSnap = 90;
         break;
       case ScreenType.ORGANIZATION_DETAILS:
         // Expand to 90% for organization details page
+        targetSnap = 90;
+        break;
+      case ScreenType.ADDRESS_DETAILS:
+        // Expand to 90% for address details page (same as organization)
+        targetSnap = 90;
+        break;
+      case ScreenType.MASTER_DETAILS:
+        // Expand to 90% for master details page
+        targetSnap = 90;
+        break;
+      case ScreenType.MASTERS_LIST:
+        // Expand to 90% for masters list page
         targetSnap = 90;
         break;
       case ScreenType.DASHBOARD:
@@ -150,7 +162,10 @@ export function MobileMapShell({
       case ScreenType.SEARCH_SUGGESTIONS:
         return 'suggest';
       case ScreenType.ORGANIZATION_DETAILS:
-        return 'results'; // Hide search bar for organization details
+      case ScreenType.ADDRESS_DETAILS:
+      case ScreenType.MASTER_DETAILS:
+      case ScreenType.MASTERS_LIST:
+        return 'results'; // Hide search bar for organization/address/master details and masters list
       default:
         return 'dashboard';
     }
@@ -159,24 +174,33 @@ export function MobileMapShell({
   // Determine header background based on screen - use solid color to prevent artifacts
   const getHeaderBackground = () => {
     return (screenState.currentScreen === ScreenType.SEARCH_RESULTS || 
-            screenState.currentScreen === ScreenType.ORGANIZATION_DETAILS) ? '#F1F1F1' : 'white';
+            screenState.currentScreen === ScreenType.ORGANIZATION_DETAILS ||
+            screenState.currentScreen === ScreenType.ADDRESS_DETAILS ||
+            screenState.currentScreen === ScreenType.MASTER_DETAILS ||
+            screenState.currentScreen === ScreenType.MASTERS_LIST) ? '#F1F1F1' : 'white';
   };
 
   // Determine content background based on screen
   const getContentBackground = () => {
     return (screenState.currentScreen === ScreenType.SEARCH_RESULTS || 
-            screenState.currentScreen === ScreenType.ORGANIZATION_DETAILS) ? '#F1F1F1' : 'white';
+            screenState.currentScreen === ScreenType.ORGANIZATION_DETAILS ||
+            screenState.currentScreen === ScreenType.ADDRESS_DETAILS ||
+            screenState.currentScreen === ScreenType.MASTER_DETAILS ||
+            screenState.currentScreen === ScreenType.MASTERS_LIST) ? '#F1F1F1' : 'white';
   };
 
   // Determine header content based on screen
   const getHeaderContent = () => {
-    // No header for ORGANIZATION_DETAILS - OrganizationPage handles its own header
+    // No header for ORGANIZATION_DETAILS or ADDRESS_DETAILS - pages handle their own headers
     return null;
   };
 
   // Determine sticky header content based on screen
   const getStickyHeaderContent = () => {
-    if (screenState.currentScreen === ScreenType.ORGANIZATION_DETAILS) {
+    if (screenState.currentScreen === ScreenType.ORGANIZATION_DETAILS || 
+        screenState.currentScreen === ScreenType.ADDRESS_DETAILS ||
+        screenState.currentScreen === ScreenType.MASTER_DETAILS ||
+        screenState.currentScreen === ScreenType.MASTERS_LIST) {
       return null;
     }
     return (

--- a/src/components/templates/ScreenRenderer.tsx
+++ b/src/components/templates/ScreenRenderer.tsx
@@ -7,6 +7,9 @@ import { SearchSuggestionsPage } from '@/components/pages/SearchSuggestionsPage'
 import { SearchResultsPage } from '@/components/pages/SearchResultsPage';
 import { DashboardPage } from '@/components/pages/DashboardPage';
 import { OrganizationPage } from '@/components/pages/OrganizationPage';
+import { AddressPage } from '@/components/pages/AddressPage';
+import { MasterDetailsPage } from '@/components/pages/MasterDetailsPage';
+import { MastersListPage } from '@/components/pages/MastersListPage';
 import { debugLog } from '@/lib/logging';
 // tokens import removed - not used
 import type { AdviceItem } from '@/__mocks__/advice/types';
@@ -62,6 +65,21 @@ export function ScreenRenderer({ items, className = '' }: ScreenRendererProps) {
       case ScreenType.ORGANIZATION_DETAILS:
         return (
           <OrganizationPage />
+        );
+      
+      case ScreenType.ADDRESS_DETAILS:
+        return (
+          <AddressPage />
+        );
+      
+      case ScreenType.MASTER_DETAILS:
+        return (
+          <MasterDetailsPage />
+        );
+      
+      case ScreenType.MASTERS_LIST:
+        return (
+          <MastersListPage />
         );
       
       default:

--- a/src/components/templates/types.ts
+++ b/src/components/templates/types.ts
@@ -3,6 +3,9 @@ export enum ScreenType {
   SEARCH_SUGGESTIONS = 'search',
   SEARCH_RESULTS = 'search-results',
   ORGANIZATION_DETAILS = 'organization-details',
+  ADDRESS_DETAILS = 'address-details',
+  MASTER_DETAILS = 'master-details',
+  MASTERS_LIST = 'masters-list',
   LOCATION_DETAILS = 'location-details',
   ROUTE_DETAILS = 'route-details'
 }

--- a/src/data/mockSearchResults.ts
+++ b/src/data/mockSearchResults.ts
@@ -1,12 +1,22 @@
 import { SearchResultCardProps } from '@/components/organisms/SearchResultCard';
 
 export const mockSearchResults: SearchResultCardProps[] = [
+  // Add an address result
+  {
+    id: 'addr-lenin-11-data',
+    name: 'ул. Ленина, 11',
+    category: 'Жилое здание',
+    address: 'ул. Ленина, 11, Новосибирск',
+    distance: '250 м',
+    type: 'address',
+  },
   {
     id: '1',
     name: 'Управление ГИБДД',
     category: 'Главное управление МВД России по Новосибирской области',
     address: 'Тверская 32/12, 1 этаж, Москва',
     distance: '3 мин',
+    type: 'organization',
     closingStatus: {
       text: 'Закроется через 30 минут',
       isWarning: true,
@@ -29,6 +39,7 @@ export const mockSearchResults: SearchResultCardProps[] = [
     reviewCount: 120,
     address: 'ул. Ленина 45, Новосибирск',
     distance: '3 мин',
+    type: 'organization',
     isAdvertiser: true,
     logo: '/icons/eae313a48883a46e7a2a60ee806e73a8052191be.png',
     gallery: [

--- a/src/data/searchResultsByQuery.ts
+++ b/src/data/searchResultsByQuery.ts
@@ -820,12 +820,23 @@ export const searchResultsByQuery: SearchResultsByQuery = {
 
   // Specific address search results
   'москва ленина 11': [
-    // Position 1: Medical center at this address
+    // Position 1: The building itself as an address result
+    {
+      id: 'addr-lenin-11',
+      name: 'ул. Ленина, 11',
+      category: 'Жилое здание',
+      address: 'ул. Ленина, 11, Москва',
+      distance: '0 м',
+      type: 'address',
+      coords: [82.9207, 55.0415],
+    },
+    // Position 2: Medical center at this address
     {
       id: 'lenin11-adv-1',
       name: 'Медицинский центр "Здоровье+"',
       category: 'Частная клиника • ул. Ленина, 11',
       isAdvertiser: true,
+      type: 'organization',
       rating: 4.7,
       reviewCount: 445,
       address: 'ул. Ленина, 11, 2 этаж',
@@ -1083,6 +1094,46 @@ export const searchResultsByQuery: SearchResultsByQuery = {
         text: 'Работает круглосуточно',
         isWarning: false,
       },
+    }
+  ],
+
+  // General address searches
+  'ленина 11': [
+    // Position 1: Address building
+    {
+      id: 'addr-lenin-11-general',
+      name: 'ул. Ленина, 11',
+      category: 'Многоквартирный дом',
+      address: 'ул. Ленина, 11, Новосибирск',
+      distance: '250 м',
+      type: 'address',
+      coords: [82.9207, 55.0415],
+    }
+  ],
+
+  'бривибас 45': [
+    // Position 1: Office building address
+    {
+      id: 'addr-brivibas-45',
+      name: 'ул. Бривибас, 45',
+      category: 'Офисное здание',
+      address: 'ул. Бривибас, 45, Рига',
+      distance: '1.2 км',
+      type: 'address',
+      coords: [24.1052, 56.9496],
+    }
+  ],
+
+  'тверская 12': [
+    // Position 1: Historic building
+    {
+      id: 'addr-tverskaya-12',
+      name: 'ул. Тверская, 12',
+      category: 'Историческое здание',
+      address: 'ул. Тверская, 12, Москва',
+      distance: '300 м',
+      type: 'address',
+      coords: [37.6173, 55.7558],
     }
   ]
 };

--- a/src/stores/slices/actions.ts
+++ b/src/stores/slices/actions.ts
@@ -4,6 +4,7 @@ import type { StateCreator } from 'zustand';
 import type { AppStore, CrossSliceActions, SearchResult, SearchSuggestion } from '../types';
 import { ScreenType } from '@/components/templates/types';
 import { debugLog } from '@/lib/logging';
+import type { Master } from '@/__mocks__/masters/data';
 
 export const createActions: StateCreator<
   AppStore,
@@ -112,13 +113,17 @@ export const createActions: StateCreator<
   selectOrganization: (organization: SearchResult) => {
     debugLog('Selecting organization:', organization);
     
-    // Set current organization in store
+    // Set current organization/address in store (reuse organization slice)
     get().organization.setCurrentOrganization(organization);
     
-    // Navigate to organization details screen
-    get().ui.navigateTo(ScreenType.ORGANIZATION_DETAILS);
+    // Navigate to appropriate details screen based on type
+    if (organization.type === 'address') {
+      get().ui.navigateTo(ScreenType.ADDRESS_DETAILS);
+    } else {
+      get().ui.navigateTo(ScreenType.ORGANIZATION_DETAILS);
+    }
     
-    // Center map on organization if it has coordinates
+    // Center map on organization/address if it has coordinates
     if (organization.coords) {
       get().map.clearMarkers();
       get().map.addMarker(organization.id, organization.coords, {
@@ -132,5 +137,23 @@ export const createActions: StateCreator<
     debugLog('Toggling filter:', filterId);
     
     get().search.toggleFilter(filterId);
+  },
+
+  selectMaster: (master: unknown) => {
+    const masterData = master as Master;
+    debugLog('Selecting master:', masterData);
+    
+    // Set master as current organization in store (reuse organization slice)
+    get().organization.setCurrentOrganization(masterData as unknown as SearchResult);
+    
+    // Navigate to master details screen
+    get().ui.navigateTo(ScreenType.MASTER_DETAILS);
+  },
+
+  showMastersList: () => {
+    debugLog('Showing masters list');
+    
+    // Navigate to masters list screen
+    get().ui.navigateTo(ScreenType.MASTERS_LIST);
   },
 });

--- a/src/stores/slices/uiSlice.ts
+++ b/src/stores/slices/uiSlice.ts
@@ -37,7 +37,7 @@ export const createUISlice: StateCreator<
           targetSnap = 90;
           break;
         case ScreenType.SEARCH_RESULTS:
-          targetSnap = 50;
+          targetSnap = 90;
           break;
         case ScreenType.ORGANIZATION_DETAILS:
           targetSnap = 90;

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -65,6 +65,8 @@ export interface SearchResult {
     products: ZMKProduct[];
   };
   coords?: [number, number];
+  // Result type to distinguish between organizations and addresses
+  type?: 'organization' | 'address';
   // Future extensibility fields
   hasLogo?: boolean;
   hasPhotos?: boolean;
@@ -155,6 +157,8 @@ export interface CrossSliceActions {
   performSearch: (query: string) => Promise<void>;
   selectLocation: (location: SearchResult | SearchSuggestion) => void;
   selectOrganization: (organization: SearchResult) => void;
+  selectMaster: (master: unknown) => void; // Using unknown to avoid circular dependency
+  showMastersList: () => void;
   focusSearchBar: () => void;
   blurSearchBar: () => void;
   clearAllState: () => void;


### PR DESCRIPTION
…ith complete navigation

- Create AddressPage component with simplified tabs (Обзор, Мастера)
- Implement MasterDetailsPage with reviews section and call-to-action button
- Add MastersListPage for "Мастера рядом" navigation from search results
- Create supporting molecules: AddressTabs, MasterCard, ReviewCard
- Add MasterDetailsHeader and MastersList organisms
- Update ScreenType enum with ADDRESS_DETAILS, MASTER_DETAILS, MASTERS_LIST
- Integrate address/building cards in search results mock data
- Fix navigation routing based on result type (address vs organization)
- Update MobileMapShell to hide SearchBar for all detail pages
- Configure auto-expand behavior: detail pages open at 90% by default
- Add master photos with circular frames (64x64px perfect circles)
- Implement gray background with white cards for better visual hierarchy
- Create comprehensive mock data for masters and reviews
- Fix all navigation handlers for seamless master selection workflow
- Update all template configurations and screen renderers

🤖 Generated with [Claude Code](https://claude.ai/code)